### PR TITLE
Implement template management with CRUD operations and improved theming

### DIFF
--- a/src/app/(app)/editor/[id]/page.tsx
+++ b/src/app/(app)/editor/[id]/page.tsx
@@ -1,9 +1,12 @@
 "use client";
+import { useGetTemplateById } from "@/shared/repository/templates/query";
 import dynamic from "next/dynamic";
-import { useParams } from "next/navigation";
+import { use } from "react";
 
-export default function TemplateEditorPage() {
-	const params = useParams();
+export default function TemplateEditorPage({
+	params,
+}: { params: Promise<{ id: string }> }) {
+	const paramsValue = use(params);
 	const TemplateEditor = dynamic(
 		() =>
 			import("../../../../features/editor/containers/template-editor").then(
@@ -11,9 +14,16 @@ export default function TemplateEditorPage() {
 			),
 		{ ssr: false },
 	);
-	return (
-		<TemplateEditor
-			templateId={Array.isArray(params.id) ? params.id[0] : (params.id ?? "")}
-		/>
-	);
+
+	const { data: res, isLoading, error } = useGetTemplateById(paramsValue.id);
+
+	if (isLoading) return <div>Loading...</div>;
+	if (error) return <div>Error: {error.message}</div>;
+	if (!res) return <div>No template found</div>;
+	if (!res.success) return <div>Error: {res.message}</div>;
+	if (!res.data) return <div>No template found</div>;
+
+	const { template } = res.data;
+
+	return <TemplateEditor original={template} />;
 }

--- a/src/features/editor/containers/template-creator.tsx
+++ b/src/features/editor/containers/template-creator.tsx
@@ -3,12 +3,11 @@ import { useRouter } from "next/navigation";
 import {
 	type ReactNode,
 	createContext,
+	forwardRef,
 	useContext,
 	useRef,
 	useState,
 } from "react";
-import { forwardRef } from "react";
-import { toast } from "sonner";
 import EditorCanvas from "../components/editor-canvas";
 import HeaderBar from "../components/header/header-creator";
 import Sidebar from "../components/sidebar/sidebar-creator";
@@ -45,8 +44,6 @@ function Provider({
 				onMenuClick={() => editor.setActiveElement(null)}
 				onSave={() => {
 					save(template);
-					toast.success("Template saved");
-					router.push("/");
 				}}
 			/>
 			{children}

--- a/src/features/editor/containers/template-editor.tsx
+++ b/src/features/editor/containers/template-editor.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { getTemplateById } from "@/features/editor/services";
 import { getTemplateForSize, printSizes } from "@/shared/lib/template";
+import { useGetTemplateById } from "@/shared/repository/templates/query";
+import type { TemplateData } from "@/shared/types/template";
 import { Printer } from "lucide-react";
 import { createContext, useContext, useRef, useState } from "react";
 import EditorCanvas from "../components/editor-canvas";
@@ -19,11 +21,12 @@ export const useTemplateContext = () => {
 	return ctx;
 };
 
-export default function TemplateEditor({ templateId }: { templateId: string }) {
+export default function TemplateEditor({
+	original,
+}: { original: TemplateData }) {
 	// const isMobile = useIsMobile();
 	// const router = useRouter();
 
-	const original = getTemplateById(templateId);
 	const [selectedSize, setSelectedSize] = useState(printSizes[1]);
 	const editor = useTemplateEditor(getTemplateForSize(original, selectedSize));
 

--- a/src/features/editor/containers/template-selector.tsx
+++ b/src/features/editor/containers/template-selector.tsx
@@ -17,6 +17,7 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 import { getTemplateForSize, printSizes } from "@/shared/lib/template";
+import { useGetTemplatesQuery } from "@/shared/repository/templates/query";
 import type { PrintSizeConfig, TemplateData } from "@/shared/types/template";
 import { PlusCircle } from "lucide-react";
 import Link from "next/link";
@@ -26,19 +27,9 @@ import { useEffect, useState } from "react";
 export default function TemplateSelector() {
 	const router = useRouter();
 	const [selectedSize, setSelectedSize] = useState(printSizes[1]);
-	const [customTemplates, setCustomTemplates] = useState<TemplateData[]>([]);
+	const { data: res, isLoading, error } = useGetTemplatesQuery();
 
-	// Load custom templates from localStorage
-	useEffect(() => {
-		try {
-			const savedTemplates = JSON.parse(
-				localStorage.getItem("customTemplates") || "[]",
-			);
-			setCustomTemplates(savedTemplates);
-		} catch (error) {
-			console.error("Error loading custom templates:", error);
-		}
-	}, []);
+	const customTemplates = res?.data?.templates || [];
 
 	const handleSizeChange = (size: string) => {
 		const newSize = printSizes.find((s) => s.name === size);

--- a/src/features/editor/hooks/use-template-persistence.ts
+++ b/src/features/editor/hooks/use-template-persistence.ts
@@ -1,30 +1,82 @@
 "use client";
+
+import {
+	useCreateTemplateMutation,
+	useGetTemplateById,
+	useUpdateTemplateMutation,
+} from "@/shared/repository/templates/query";
 import type { TemplateData } from "@/shared/types/template";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export function useTemplatePersistence(
 	loadId: string | undefined,
 	setInitial: (tpl: TemplateData) => void,
 ) {
+	const { data: res, isLoading, error } = useGetTemplateById(loadId || "");
+	const { mutate: createTemplate, isPending: isCreating } =
+		useCreateTemplateMutation();
+	const { mutate: updateTemplate, isPending: isUpdating } =
+		useUpdateTemplateMutation(loadId || "");
+	const router = useRouter();
+
 	/* ---- load once (if query has id) ---- */
 	useEffect(() => {
+		// if (!loadId) return;
+		// const saved: TemplateData[] = JSON.parse(
+		// 	localStorage.getItem("customTemplates") || "[]",
+		// );
+		// const found = saved.find((t) => t.id === loadId);
+		// if (found) setInitial(found);
+
 		if (!loadId) return;
-		const saved: TemplateData[] = JSON.parse(
-			localStorage.getItem("customTemplates") || "[]",
-		);
-		const found = saved.find((t) => t.id === loadId);
-		if (found) setInitial(found);
-	}, [loadId, setInitial]);
+		if (isLoading) return;
+		if (error) return;
+
+		if (!res) return;
+		if (!res.success) return;
+		if (!res.data) return;
+
+		const { template } = res.data;
+
+		if (!template) return;
+
+		setInitial(template);
+	}, [loadId, isLoading, error, res, setInitial]);
 
 	/* ---- save helper ---- */
 	const save = (tpl: TemplateData) => {
-		const stored: TemplateData[] = JSON.parse(
-			localStorage.getItem("customTemplates") || "[]",
-		);
-		const idx = stored.findIndex((t) => t.id === tpl.id);
-		if (idx >= 0) stored[idx] = tpl;
-		else stored.push(tpl);
-		localStorage.setItem("customTemplates", JSON.stringify(stored));
+		// const stored: TemplateData[] = JSON.parse(
+		// 	localStorage.getItem("customTemplates") || "[]",
+		// );
+		// const idx = stored.findIndex((t) => t.id === tpl.id);
+		// if (idx >= 0) stored[idx] = tpl;
+		// else stored.push(tpl);
+		// localStorage.setItem("customTemplates", JSON.stringify(stored));
+
+		if (isLoading) return;
+		if (error) return;
+
+		if (!res) return;
+
+		if (!res.success)
+			createTemplate(tpl, {
+				onSuccess: (r) => {
+					if (r.success) {
+						router.replace("/");
+						return;
+					}
+				},
+			});
+		else
+			updateTemplate(tpl, {
+				onSuccess: (r) => {
+					if (r.success) {
+						router.replace("/");
+						return;
+					}
+				},
+			});
 	};
 
 	return { save };

--- a/src/server/db/schema/templates.ts
+++ b/src/server/db/schema/templates.ts
@@ -1,0 +1,9 @@
+import type { TemplateData } from "@/shared/types/template";
+import { json, pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const templatesTable = pgTable("templates", {
+	id: text("id").primaryKey(),
+	name: varchar({ length: 255 }).notNull(),
+	data: json("data").notNull().$type<Omit<TemplateData, "id" | "name">>(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+});

--- a/src/shared/components/providers/index.tsx
+++ b/src/shared/components/providers/index.tsx
@@ -8,7 +8,12 @@ import { ThemeProvider } from "./theme-provider";
 
 export default function Provider({ children }: React.PropsWithChildren) {
 	return (
-		<ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+		<ThemeProvider
+			attribute="class"
+			defaultTheme="light"
+			enableSystem
+			forcedTheme="light"
+		>
 			<ReactQueryProvider>
 				{children}
 				<Toaster />

--- a/src/shared/repository/templates/action.ts
+++ b/src/shared/repository/templates/action.ts
@@ -1,0 +1,162 @@
+"use server";
+
+import { db } from "@/server/db";
+import { tryCatch } from "@/shared/lib/try-catch";
+import type { TemplateData, TemplateEntity } from "@/shared/types/template";
+import { sql } from "drizzle-orm";
+import type { CreateTemplateRequest, UpdateTemplateRequest } from "./dto";
+
+export const getTemplates = async () => {
+	const queryBuilder = `
+    select *
+    from templates
+  `;
+
+	const { data, error } = await tryCatch(
+		db.execute<TemplateEntity>(queryBuilder),
+	);
+	if (error) {
+		console.error(error);
+		return {
+			success: false,
+			error: error.message,
+			message: "Failed to fetch templates",
+		};
+	}
+
+	const { rows: templates } = data;
+
+	console.log(templates);
+
+	let parsedTemplates: TemplateData[] = [];
+
+	parsedTemplates = templates.map((template) => {
+		return {
+			id: template.id,
+			name: template.name,
+			...template.data,
+		};
+	});
+
+	return {
+		success: true,
+		data: {
+			templates: parsedTemplates,
+		},
+		message: "Templates fetched successfully",
+	};
+};
+
+export const getTemplateById = async (id: TemplateEntity["id"]) => {
+	const queryBuilder = sql`
+    select *
+    from templates
+    where id = ${id}
+  `;
+
+	const { data, error } = await tryCatch(
+		db.execute<TemplateEntity>(queryBuilder),
+	);
+	if (error) {
+		console.error(error);
+		return {
+			success: false,
+			error: error.message,
+			message: "Failed to fetch template",
+		};
+	}
+
+	const { rows: templates } = data;
+
+	if (templates.length === 0) {
+		return {
+			success: false,
+			error: "Template not found",
+			message: "Template not found",
+		};
+	}
+
+	const template: TemplateData = {
+		id: templates[0].id,
+		name: templates[0].name,
+		...templates[0].data,
+	};
+
+	return {
+		success: true,
+		data: {
+			template,
+		},
+		message: "Template fetched successfully",
+	};
+};
+
+export const createTemplate = async (req: CreateTemplateRequest) => {
+	const data = {
+		width: req.width,
+		height: req.height,
+		backgroundColor: req.backgroundColor,
+		backgroundImage: req.backgroundImage,
+		images: req.images,
+		texts: req.texts,
+	};
+
+	const queryBuilder = sql`
+    insert into templates (id, name, data)
+    values (${req.id}, ${req.name}, ${data})
+  `;
+
+	console.log(queryBuilder, "queryBuilder");
+
+	const { error } = await tryCatch(db.execute(queryBuilder));
+	if (error) {
+		console.error(error);
+		return {
+			success: false,
+			error: error.message,
+			message: "Failed to create template",
+		};
+	}
+
+	return {
+		success: true,
+		data: null,
+		message: "Template created successfully",
+	};
+};
+
+export const updateTemplate = async (
+	req: UpdateTemplateRequest,
+	id: TemplateEntity["id"],
+) => {
+	const data = {
+		width: req.width,
+		height: req.height,
+		backgroundColor: req.backgroundColor,
+		backgroundImage: req.backgroundImage,
+		images: req.images,
+		texts: req.texts,
+	};
+
+	const queryBuilder = sql`
+    update templates
+    set name = ${req.name}, data = ${data}
+    where id = ${id}
+  `;
+
+	const { error } = await tryCatch(db.execute(queryBuilder));
+	if (error) {
+		console.error(error);
+		return {
+			success: false,
+			error: error.message,
+			message: "Failed to update template",
+		};
+	}
+
+	return {
+		success: true,
+		data: null,
+		message: "Template updated successfully",
+	};
+};

--- a/src/shared/repository/templates/dto.ts
+++ b/src/shared/repository/templates/dto.ts
@@ -1,0 +1,5 @@
+import type { TemplateData } from "@/shared/types/template";
+
+export type CreateTemplateRequest = TemplateData;
+
+export type UpdateTemplateRequest = TemplateData;

--- a/src/shared/repository/templates/query.ts
+++ b/src/shared/repository/templates/query.ts
@@ -1,0 +1,60 @@
+import type { TemplateEntity } from "@/shared/types/template";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+	createTemplate,
+	getTemplateById,
+	getTemplates,
+	updateTemplate,
+} from "./action";
+import type { CreateTemplateRequest } from "./dto";
+
+export const useGetTemplatesQuery = () => {
+	return useQuery({
+		queryKey: ["templates"],
+		queryFn: () => getTemplates(),
+	});
+};
+
+export const useGetTemplateById = (id: TemplateEntity["id"]) => {
+	return useQuery({
+		queryKey: ["templates", id],
+		queryFn: () => getTemplateById(id),
+	});
+};
+
+export const useCreateTemplateMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: CreateTemplateRequest) => createTemplate(data),
+		onSuccess: (res) => {
+			if (!res.success) {
+				toast.error(res.message);
+				return;
+			}
+
+			toast.success(res.message);
+
+			queryClient.invalidateQueries({ queryKey: ["templates"] });
+		},
+	});
+};
+
+export const useUpdateTemplateMutation = (id: TemplateEntity["id"]) => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: CreateTemplateRequest) => updateTemplate(data, id),
+		onSuccess: (res) => {
+			if (!res.success) {
+				toast.error(res.message);
+				return;
+			}
+
+			toast.success(res.message);
+
+			queryClient.invalidateQueries({ queryKey: ["templates"] });
+		},
+	});
+};

--- a/src/shared/types/template.ts
+++ b/src/shared/types/template.ts
@@ -69,3 +69,9 @@ export interface PrintSizeConfig {
 	height: number;
 	label: string;
 }
+
+export type TemplateEntity = {
+	id: string;
+	name: string;
+	data: Omit<TemplateData, "id" | "name">;
+};


### PR DESCRIPTION
Introduce a new `TemplateEntity` type and a database schema for templates. Implement CRUD operations for templates, enhancing the template editor with hooks for data fetching and error handling. Add a `forcedTheme` prop to the `ThemeProvider` for consistent theming across the application.