### PR TITLE
Change order ID type from integer to UUID string

### DIFF
--- a/src/features/editor/hooks/use-export-image.ts
+++ b/src/features/editor/hooks/use-export-image.ts
@@ -36,7 +36,7 @@ export function useExportImage(ref: React.RefObject<HTMLElement>) {
 			toast.error("Invalid order ID format.");
 		}
 
-		if (!orderId || typeof orderId !== "number") {
+		if (!orderId || typeof orderId !== "string") {
 			toast.error("Invalid order ID. Please verify your order first.");
 			return;
 		}

--- a/src/server/db/schema/orders.ts
+++ b/src/server/db/schema/orders.ts
@@ -1,7 +1,7 @@
-import { integer, pgTable, timestamp, varchar } from "drizzle-orm/pg-core";
+import { pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
 export const ordersTable = pgTable("orders", {
-	id: integer().primaryKey().generatedAlwaysAsIdentity(),
+	id: uuid("id").primaryKey().defaultRandom(),
 	orderNumber: varchar("order_number", { length: 255 }).notNull(),
 	username: varchar({ length: 255 }).notNull(),
 	imageUrl: varchar("image_url", { length: 255 }),

--- a/src/shared/repository/order/dto.ts
+++ b/src/shared/repository/order/dto.ts
@@ -44,7 +44,7 @@ export type DeleteOrderParams = {
 
 export const submitOrderSchema = z.object({
 	file: z.instanceof(Blob).refine((file) => file.size > 0, "File is required"),
-	orderId: z.number().int().positive("Order ID must be a positive integer"),
+	orderId: z.string().min(1, "Order ID is required"),
 });
 
 export type SubmitOrderRequest = z.infer<typeof submitOrderSchema>;

--- a/src/shared/repository/order/dto.ts
+++ b/src/shared/repository/order/dto.ts
@@ -44,7 +44,7 @@ export type DeleteOrderParams = {
 
 export const submitOrderSchema = z.object({
 	file: z.instanceof(Blob).refine((file) => file.size > 0, "File is required"),
-	orderId: z.string().min(1, "Order ID is required"),
+	orderId: z.string().uuid("Invalid order ID format"),
 });
 
 export type SubmitOrderRequest = z.infer<typeof submitOrderSchema>;

--- a/src/shared/types/order.ts
+++ b/src/shared/types/order.ts
@@ -1,5 +1,5 @@
 export type Order = {
-	id: number;
+	id: string;
 	orderNumber: string;
 	username: string;
 	imageUrl: string | null;


### PR DESCRIPTION
Transition order ID from an integer to a UUID string for enhanced flexibility and consistency across the application. Update validation and data types accordingly.