### PR TITLE
Improve shape and line element controller by adding z-index, line tip, line stroke width adjustment

### DIFF
--- a/src/features/editor/components/editor-canvas.tsx
+++ b/src/features/editor/components/editor-canvas.tsx
@@ -131,7 +131,7 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 				{/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
 				<div
 					ref={ref}
-					className="relative bg-white shadow-lg"
+					className="relative bg-white shadow-lg overflow-clip"
 					style={{
 						width: template.width * scale,
 						height: template.height * scale,
@@ -239,6 +239,8 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 							}}
 							getSnapPosition={getSnapPosition}
 							constrainToCanvas={constrainToCanvas}
+							canvasWidth={template.width}
+							canvasHeight={template.height}
 						/>
 					))}
 
@@ -264,6 +266,8 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 									),
 								}))
 							}
+							canvasWidth={template.width}
+							canvasHeight={template.height}
 						/>
 					))}
 					<div className="absolute -bottom-8 w-full text-center text-xs text-gray-500 flex items-center justify-center">

--- a/src/features/editor/components/tabs/creator/shapes-lines-tab.tsx
+++ b/src/features/editor/components/tabs/creator/shapes-lines-tab.tsx
@@ -60,7 +60,14 @@ export default function ShapesLinesTab() {
 }
 
 function LinesTabContent() {
-	const { template, updateLine, deleteElement } = useTemplateContext();
+	const {
+		template,
+		updateLine,
+		deleteElement,
+		activeElement,
+		setActiveElement,
+		totalElements,
+	} = useTemplateContext();
 	const lines = template.lines;
 	return (
 		<>
@@ -74,12 +81,25 @@ function LinesTabContent() {
 						</span>
 					</div>
 
-					<Accordion type="single" className="space-y-2">
+					<Accordion
+						type="single"
+						className="space-y-2"
+						collapsible
+						value={activeElement || undefined}
+						onValueChange={setActiveElement}
+					>
 						{lines.map((line, idx) => (
 							<AccordionItem
 								key={line.id}
 								value={line.id}
-								className="border rounded-md"
+								className={cn(
+									"border-2 last:border-b-2 rounded-md",
+									activeElement === line.id && "border-black",
+								)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setActiveElement(line.id);
+								}}
 							>
 								<div>
 									<AccordionTrigger className="p-2 gap-1">
@@ -94,6 +114,7 @@ function LinesTabContent() {
 										<LineConfigurator
 											line={line}
 											onUpdate={(updates) => updateLine(line.id, updates)}
+											totalElement={totalElements}
 										/>
 									</AccordionContent>
 								</div>
@@ -107,7 +128,14 @@ function LinesTabContent() {
 }
 
 function ShapeTabContent() {
-	const { template, deleteElement, updateShape } = useTemplateContext();
+	const {
+		template,
+		deleteElement,
+		updateShape,
+		activeElement,
+		setActiveElement,
+		totalElements,
+	} = useTemplateContext();
 	const shapes = template.shapes;
 
 	return (
@@ -122,12 +150,25 @@ function ShapeTabContent() {
 						</span>
 					</div>
 
-					<Accordion type="single" collapsible className="space-y-2">
+					<Accordion
+						type="single"
+						collapsible
+						className="space-y-2"
+						value={activeElement || undefined}
+						onValueChange={setActiveElement}
+					>
 						{shapes.map((shape, idx) => (
 							<AccordionItem
 								key={shape.id}
 								value={shape.id}
-								className="border rounded-md"
+								className={cn(
+									"border-2 last:border-b-2 rounded-md",
+									activeElement === shape.id && "border-black",
+								)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setActiveElement(shape.id);
+								}}
 							>
 								<div>
 									<AccordionTrigger className="p-2 gap-1">
@@ -142,6 +183,7 @@ function ShapeTabContent() {
 										<ShapeConfigurator
 											shape={shape}
 											onUpdate={(updates) => updateShape(shape.id, updates)}
+											totalElement={totalElements}
 										/>
 									</AccordionContent>
 								</div>

--- a/src/features/editor/components/template-elements/template-line.tsx
+++ b/src/features/editor/components/template-elements/template-line.tsx
@@ -161,6 +161,7 @@ export default function TemplateLine(props: Props) {
 				width: `${Math.abs(dx) * scale}px`,
 				height: `${strokeWidth * scale}px`,
 				pointerEvents: "none",
+				zIndex: props.element.zIndex || 1,
 			}}
 		>
 			<svg

--- a/src/features/editor/components/template-elements/template-line.tsx
+++ b/src/features/editor/components/template-elements/template-line.tsx
@@ -26,7 +26,6 @@ function renderLineTip({
 	angle,
 	strokeColor,
 	strokeWidth,
-	scale,
 }: {
 	tip: string;
 	isStart: boolean;
@@ -35,7 +34,6 @@ function renderLineTip({
 	angle: number;
 	strokeColor: string;
 	strokeWidth: number;
-	scale: number;
 }) {
 	if (tip === "none") return null;
 
@@ -65,7 +63,7 @@ function renderLineTip({
 	}
 
 	if (tip === "rounded") {
-		const radius = Math.max(strokeWidth / 4, 1) * scale;
+		const radius = strokeWidth * 0.5;
 		return (
 			<circle cx={xPosition} cy={yPosition} r={radius} fill={strokeColor} />
 		);
@@ -85,7 +83,7 @@ function getTipSize(tip: string, strokeWidth: number): number {
 	if (tip === "none") return 0;
 
 	if (tip === "arrow") {
-		return Math.max(strokeWidth * 2, 8);
+		return Math.max(strokeWidth * 1.8, 8);
 	}
 
 	if (tip === "circle") {
@@ -93,7 +91,7 @@ function getTipSize(tip: string, strokeWidth: number): number {
 	}
 
 	if (tip === "rounded") {
-		return Math.max(strokeWidth / 8, 0.5);
+		return strokeWidth * 0.05;
 	}
 
 	// Default tip size
@@ -193,7 +191,11 @@ export default function TemplateLine(props: Props) {
 						}}
 					/>
 
-					<g>
+					<g
+						style={{
+							opacity: element.opacity / 100,
+						}}
+					>
 						{/* Visible line (trimmed if tips are present) */}
 						<line
 							x1={trimmedStartX}
@@ -215,7 +217,6 @@ export default function TemplateLine(props: Props) {
 							angle,
 							strokeColor,
 							strokeWidth: strokeWidth * scale,
-							scale,
 						})}
 						{renderLineTip({
 							tip: endTip,
@@ -225,13 +226,28 @@ export default function TemplateLine(props: Props) {
 							angle,
 							strokeColor,
 							strokeWidth: strokeWidth * scale,
-							scale,
 						})}
 					</g>
 
 					{/* Active Selection - Keep handles outside clipping */}
 					{props.isElementActive && (
 						<>
+							{/* dash line for showing selection */}
+							<line
+								x1={trimmedStartX}
+								y1={trimmedStartY}
+								x2={trimmedEndX}
+								y2={trimmedEndY}
+								stroke={
+									["line-dashed", "line-dotted"].includes(props.element.type)
+										? "#1E88E5"
+										: "#fff"
+								}
+								// max width is 10px
+								strokeWidth={Math.min(strokeWidth * scale * 0.5, 2)}
+								strokeDasharray="4,4"
+								style={{ pointerEvents: "none" }}
+							/>
 							<circle
 								cx={0}
 								cy={0}
@@ -245,6 +261,7 @@ export default function TemplateLine(props: Props) {
 									startEndpointDrag("start")(e);
 								}}
 							/>
+							{/* dash line */}
 							<circle
 								cx={dx * scale}
 								cy={dy * scale}

--- a/src/features/editor/components/template-elements/template-shape.tsx
+++ b/src/features/editor/components/template-elements/template-shape.tsx
@@ -92,15 +92,10 @@ export default function TemplateShape(props: Props) {
 				width: scaledWidth,
 				height: scaledHeight,
 				pointerEvents: props.isPreview ? "none" : "auto",
+				zIndex: props.element.zIndex || 1,
 			}}
 		>
-			{/* Shape Preview - Only clip the shape content, not the handles */}
-			<div
-				className="w-full h-full"
-				// style={{
-				// 	clipPath: getClipPath(),
-				// }}
-			>
+			<div className="w-full h-full">
 				{/* Rectangle */}
 				{props.element.type === "rectangle" && (
 					<div

--- a/src/features/editor/hooks/use-template-editor.ts
+++ b/src/features/editor/hooks/use-template-editor.ts
@@ -7,7 +7,7 @@ import type {
 	TemplateData,
 	TextElement,
 } from "@/shared/types/template";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { getLineConfig } from "../utils/line-config";
 
@@ -24,6 +24,20 @@ export function useTemplateEditor(initial?: TemplateData) {
 			shapes: [],
 			lines: [],
 		},
+	);
+
+	const totalElements = useMemo(
+		() =>
+			template.shapes.length +
+			template.lines.length +
+			template.texts.length +
+			template.images.length,
+		[
+			template.shapes.length,
+			template.lines.length,
+			template.texts.length,
+			template.images.length,
+		],
 	);
 
 	const [activeElement, setActiveElement] = useState<string | null>(null);
@@ -236,5 +250,6 @@ export function useTemplateEditor(initial?: TemplateData) {
 		sendBackward,
 		bringToFront,
 		sendToBack,
+		totalElements,
 	};
 }

--- a/src/features/editor/hooks/use-template-editor.ts
+++ b/src/features/editor/hooks/use-template-editor.ts
@@ -12,29 +12,20 @@ import { v4 as uuidv4 } from "uuid";
 import { getLineConfig } from "../utils/line-config";
 
 export function useTemplateEditor(initial?: TemplateData) {
-	// const [template, setTemplate] = useState<TemplateData>(
-	// 	initial ?? {
-	// 		id: uuidv4(),
-	// 		name: "Custom Template",
-	// 		width: printSizes[1].width,
-	// 		height: printSizes[1].height,
-	// 		backgroundColor: "#ffffff",
-	// 		images: [],
-	// 		texts: [],
-	//     shapes: [],
-	// 	},
-	// );
-	const [template, setTemplate] = useState<TemplateData>({
-		id: uuidv4(),
-		name: "Custom Template",
-		width: 10 * 40, // default width in pixels (10cm * 40px/cm)
-		height: 20 * 40, // default height in pixels (20cm * 40px/cm)
-		backgroundColor: "#ffffff",
-		images: [],
-		texts: [],
-		shapes: [],
-		lines: [],
-	});
+	const [template, setTemplate] = useState<TemplateData>(
+		initial ?? {
+			id: uuidv4(),
+			name: "Custom Template",
+			width: 10 * 40,
+			height: 20 * 40,
+			backgroundColor: "#ffffff",
+			images: [],
+			texts: [],
+			shapes: [],
+			lines: [],
+		},
+	);
+
 	const [activeElement, setActiveElement] = useState<string | null>(null);
 
 	const addImage = (): string => {
@@ -95,6 +86,7 @@ export function useTemplateEditor(initial?: TemplateData) {
 			borderRadius: 0,
 			opacity: 100,
 			draggable: true,
+			zIndex: 1,
 		};
 
 		setTemplate((p) => {

--- a/src/features/editor/utils/line-config.ts
+++ b/src/features/editor/utils/line-config.ts
@@ -6,12 +6,13 @@ export const getLineConfig = (type: LineElement["type"]): LineElement => {
 		draggable: true,
 		strokeColor: "#000000",
 		strokeWidth: 2,
-		opacity: 1,
+		opacity: 100,
 		// start and end point in center of the canvas
 		startPoint: { x: 0, y: 0 },
 		endPoint: { x: 50, y: 0 },
 		startTip: "none",
 		endTip: "none",
+		zIndex: 1,
 	};
 
 	switch (type) {

--- a/src/shared/components/shape-lines/configurator/LineConfigurator.tsx
+++ b/src/shared/components/shape-lines/configurator/LineConfigurator.tsx
@@ -1,14 +1,29 @@
-import type { LineElement } from "@/shared/types/element/line";
+import {
+	LINE_TIP,
+	type LineElement,
+	type LineTip,
+} from "@/shared/types/element/line";
 import { Input } from "../../ui/input";
+import { Label } from "../../ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../ui/select";
 import { OpacityControl } from "../controls";
 import ColorPicker from "../controls/ColorPicker";
+import { ZIndexControls } from "./ShapeConfigurator";
 
 export default function LineConfigurator({
 	line,
 	onUpdate,
+	totalElement,
 }: {
 	line: LineElement;
 	onUpdate: (updates: Partial<LineElement>) => void;
+	totalElement: number;
 }) {
 	return (
 		<div className="space-y-4">
@@ -34,6 +49,69 @@ export default function LineConfigurator({
 				opacity={line.opacity}
 				onChange={(opacity) => onUpdate({ opacity })}
 			/>
+			<ZIndexControls
+				element={line}
+				onUpdate={(zIndex) => onUpdate({ zIndex })}
+				totalElement={totalElement}
+			/>
+			<LineTipControls
+				startTip={line.startTip}
+				endTip={line.endTip}
+				onChange={onUpdate}
+			/>
+			<LineWidthControls
+				strokeWidth={line.strokeWidth}
+				onUpdate={(strokeWidth) => onUpdate({ strokeWidth })}
+			/>
+		</div>
+	);
+}
+
+function LineTipControls({
+	startTip,
+	endTip,
+	onChange,
+}: {
+	startTip: LineTip | undefined;
+	endTip: LineTip | undefined;
+	onChange: (updates: Partial<LineElement>) => void;
+}) {
+	return (
+		<div className="space-y-2">
+			{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+			<label className="text-xs font-medium">Line Tip</label>
+			<div className="flex gap-x-2">
+				<Select
+					value={startTip}
+					onValueChange={(value) => onChange({ startTip: value as LineTip })}
+				>
+					<SelectTrigger>
+						<SelectValue placeholder="Select a line tip" />
+					</SelectTrigger>
+					<SelectContent>
+						{Object.entries(LINE_TIP).map(([key, value]) => (
+							<SelectItem key={key} value={value}>
+								{key}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Select
+					value={endTip}
+					onValueChange={(value) => onChange({ endTip: value as LineTip })}
+				>
+					<SelectTrigger>
+						<SelectValue placeholder="Select a line tip" />
+					</SelectTrigger>
+					<SelectContent>
+						{Object.entries(LINE_TIP).map(([key, value]) => (
+							<SelectItem key={key} value={value}>
+								{key}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
 		</div>
 	);
 }
@@ -62,6 +140,8 @@ function LinePositionControls({
 			{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
 			<label className="text-xs font-medium">Start Position</label>
 			<div className="flex space-x-2">
+				{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+				<label className="text-xs font-medium">X</label>
 				<Input
 					type="number"
 					value={startX}
@@ -75,6 +155,8 @@ function LinePositionControls({
 					}
 					placeholder="Start X"
 				/>
+				{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+				<label className="text-xs font-medium">Y</label>
 				<Input
 					type="number"
 					value={startY}
@@ -92,6 +174,8 @@ function LinePositionControls({
 			{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
 			<label className="text-xs font-medium">End Position</label>
 			<div className="flex space-x-2">
+				{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+				<label className="text-xs font-medium">X</label>
 				<Input
 					type="number"
 					value={endX}
@@ -105,6 +189,8 @@ function LinePositionControls({
 					}
 					placeholder="End X"
 				/>
+				{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+				<label className="text-xs font-medium">Y</label>
 				<Input
 					type="number"
 					value={endY}
@@ -119,6 +205,31 @@ function LinePositionControls({
 					placeholder="End Y"
 				/>
 			</div>
+		</div>
+	);
+}
+
+function LineWidthControls({
+	strokeWidth,
+	onUpdate,
+}: {
+	strokeWidth: number;
+	onUpdate: (strokeWidth: number) => void;
+}) {
+	return (
+		<div className="space-y-2">
+			{/* biome-ignore lint/a11y/noLabelWithoutControl: <explanation> */}
+			<label className="text-xs font-medium">Line Width</label>
+			<Input
+				type="number"
+				value={strokeWidth}
+				onChange={(e) => onUpdate(Number.parseFloat(e.target.value))}
+				min={1}
+				max={100}
+				step={1}
+				className="w-full"
+				placeholder="Enter line width"
+			/>
 		</div>
 	);
 }

--- a/src/shared/components/shape-lines/configurator/LineConfigurator.tsx
+++ b/src/shared/components/shape-lines/configurator/LineConfigurator.tsx
@@ -1,6 +1,6 @@
 import type { LineElement } from "@/shared/types/element/line";
 import { Input } from "../../ui/input";
-import { OpacityControl, RotationControl } from "../controls";
+import { OpacityControl } from "../controls";
 import ColorPicker from "../controls/ColorPicker";
 
 export default function LineConfigurator({

--- a/src/shared/components/shape-lines/configurator/ShapeConfigurator.tsx
+++ b/src/shared/components/shape-lines/configurator/ShapeConfigurator.tsx
@@ -1,4 +1,12 @@
+import type { LineElement } from "@/shared/types/element/line";
 import type { ShapeElement } from "@/shared/types/element/shape";
+import {
+	ArrowDown,
+	ArrowDownToLine,
+	ArrowUp,
+	ArrowUpToLine,
+} from "lucide-react";
+import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import {
@@ -13,9 +21,11 @@ import {
 export default function ShapeConfigurator({
 	shape,
 	onUpdate,
+	totalElement,
 }: {
 	shape: ShapeElement;
 	onUpdate: (updates: Partial<ShapeElement>) => void;
+	totalElement: number;
 }) {
 	return (
 		<div className="space-y-4">
@@ -63,6 +73,104 @@ export default function ShapeConfigurator({
 				opacity={shape.opacity}
 				onChange={(opacity) => onUpdate({ opacity })}
 			/>
+			<ZIndexControls
+				element={shape}
+				onUpdate={(zIndex) => onUpdate({ zIndex })}
+				totalElement={totalElement}
+			/>
+		</div>
+	);
+}
+
+export function ZIndexControls({
+	element,
+	onUpdate,
+	totalElement,
+}: {
+	element: LineElement | ShapeElement;
+	onUpdate: (updates: number) => void;
+	totalElement: number;
+}) {
+	// normalize zIndex for backward compatibility
+	const currentZIndex = element.zIndex ?? 1;
+
+	const bringForward = () => {
+		if (currentZIndex >= totalElement) return;
+		onUpdate(currentZIndex + 1);
+	};
+
+	const sendBackward = () => {
+		if (currentZIndex <= 1) return;
+		onUpdate(currentZIndex - 1);
+	};
+
+	const bringToFront = () => {
+		if (currentZIndex === totalElement) return;
+		onUpdate(totalElement);
+	};
+
+	const sendToBack = () => {
+		if (currentZIndex === 1) return;
+		onUpdate(1);
+	};
+
+	return (
+		<div>
+			<Label className="text-xs font-medium">Z Index</Label>
+			<div className="flex flex-wrap gap-2 mt-1">
+				<Button
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs"
+					disabled={currentZIndex >= totalElement}
+					onClick={(e) => {
+						e.stopPropagation();
+						bringForward();
+					}}
+				>
+					<ArrowUp className="w-4 h-4 mr-1" />
+					Forward
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs"
+					disabled={currentZIndex <= 1}
+					onClick={(e) => {
+						e.stopPropagation();
+						sendBackward();
+					}}
+				>
+					<ArrowDown className="w-4 h-4 mr-1" />
+					Backward
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs"
+					disabled={currentZIndex >= totalElement}
+					onClick={(e) => {
+						e.stopPropagation();
+						bringToFront();
+					}}
+				>
+					<ArrowUp className="w-4 h-4 mr-1" />
+					To Front
+				</Button>
+				<Button
+					variant="outline"
+					size="sm"
+					className="h-7 text-xs"
+					disabled={currentZIndex <= 1}
+					onClick={(e) => {
+						e.stopPropagation();
+						sendToBack();
+					}}
+				>
+					<ArrowDown className="w-4 h-4 mr-1" />
+					To Back
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/shared/types/element/line.ts
+++ b/src/shared/types/element/line.ts
@@ -9,9 +9,16 @@ export type TLineElement =
 	| "line-arrow"
 	| "line-rounded";
 
-export interface LineTip {
-	type: "none" | "arrow" | "circle" | "square" | "rounded";
-}
+export const LINE_TIP = {
+	NONE: "none",
+	ARROW: "arrow",
+	CIRCLE: "circle",
+	SQUARE: "square",
+	ROUNDED: "rounded",
+} as const;
+
+export type LineTip = (typeof LINE_TIP)[keyof typeof LINE_TIP];
+
 export interface LineElement {
 	id: string;
 	type: TLineElement;
@@ -21,9 +28,7 @@ export interface LineElement {
 	opacity: number;
 	startPoint: Position;
 	endPoint: Position;
-	startTip?: string;
-	endTip?: string;
+	startTip?: LineTip;
+	endTip?: LineTip;
 	zIndex?: number;
-	// startTipSize?: number;
-	// endTipSize?: number;
 }

--- a/src/shared/types/element/line.ts
+++ b/src/shared/types/element/line.ts
@@ -23,6 +23,7 @@ export interface LineElement {
 	endPoint: Position;
 	startTip?: string;
 	endTip?: string;
+	zIndex?: number;
 	// startTipSize?: number;
 	// endTipSize?: number;
 }

--- a/src/shared/types/element/shape.ts
+++ b/src/shared/types/element/shape.ts
@@ -15,4 +15,5 @@ export interface ShapeElement {
 	borderWidth: number;
 	borderRadius: number;
 	opacity: number;
+	zIndex: number;
 }


### PR DESCRIPTION
This pull request introduces several improvements to the editor's handling of shapes and lines, focusing on enhanced configurability, better rendering, and improved state management. The main changes include new controls for line tips and z-index, adjustments to the rendering logic for lines and shapes, and refactoring of context and hooks to support these features.

**Editor configurability and controls:**

* Added `LineTipControls`, `LineWidthControls`, and `ZIndexControls` to the `LineConfigurator`, allowing users to customize line tips, width, and stacking order directly in the UI. Also added explicit X/Y labels to position controls for clarity. (`src/shared/components/shape-lines/configurator/LineConfigurator.tsx`) [[1]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR52-R114) [[2]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR143-R144) [[3]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR158-R159) [[4]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR177-R178) [[5]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR192-R193) [[6]](diffhunk://#diff-894b40c032d0c84e8b54f20470f057f7e9f836233004e0580475887630a3e03aR211-R235)

**Rendering and visual improvements:**

* Updated rendering logic for lines and shapes to use the `zIndex` property, ensuring correct stacking order in the editor. Also added dashed selection outlines for active lines and improved opacity handling for line elements. (`src/features/editor/components/template-elements/template-line.tsx`, `src/features/editor/components/template-elements/template-shape.tsx`) [[1]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101R162) [[2]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L195-R198) [[3]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L227-R250) [[4]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101R264) [[5]](diffhunk://#diff-c76c5f993c1684a4ad3384d1267b50f9ddfbb27591c0c2e9362733237ab07e8aR95-R98)

* Refined line tip rendering and sizing logic for more consistent appearance, including removal of unnecessary scaling and improved tip size calculations. (`src/features/editor/components/template-elements/template-line.tsx`) [[1]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L29) [[2]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L38) [[3]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L68-R66) [[4]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L88-R94) [[5]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L217)

**Context and state management:**

* Enhanced the template editor hook (`useTemplateEditor`) to support initialization from props, added a computed `totalElements` value, and included `zIndex` in element creation defaults. (`src/features/editor/hooks/use-template-editor.ts`, `src/features/editor/utils/line-config.ts`) [[1]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504L10-R42) [[2]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504R103) [[3]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504R253) [[4]](diffhunk://#diff-25a3e34b0c86da32361319c99725c491e53056fbdf63c16eccb1dc8eae3699bbL9-R15)

**UI and interaction improvements:**

* Updated the shapes and lines tabs to support active element selection and highlight, passing `totalElements` and active state to configurators for better user feedback. (`src/features/editor/components/tabs/creator/shapes-lines-tab.tsx`) [[1]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63L63-R70) [[2]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63L77-R102) [[3]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63R117) [[4]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63L110-R138) [[5]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63L125-R171) [[6]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63R186)

**Canvas and element sizing:**

* Ensured canvas and element components receive explicit width and height props, and added `overflow-clip` to the canvas for improved layout control. (`src/features/editor/components/editor-canvas.tsx`) [[1]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3L134-R134) [[2]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3R242-R243) [[3]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3R269-R270)

These changes collectively make the editor more flexible, visually consistent, and easier to use for customizing shapes and lines.