### PR TITLE
Implement layering system for element management

### DIFF
--- a/src/features/editor/components/editor-canvas.tsx
+++ b/src/features/editor/components/editor-canvas.tsx
@@ -8,8 +8,8 @@ import { useKeyboardDelete } from "@/features/editor/hooks/use-keyboard-delete";
 import { validateTextElement } from "@/shared/lib/elements";
 import type { TemplateData } from "@/shared/types/template";
 import { Printer } from "lucide-react";
-import { forwardRef, useEffect, useState } from "react";
 import type React from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useAlignmentGuides } from "../hooks/use-allignment-guides";
 import { useAutoTextHeight } from "../hooks/use-auto-text-height";
@@ -30,6 +30,7 @@ interface EditorCanvasProps {
 	isCustomizing?: boolean;
 	initialTemplate?: TemplateData;
 	allowDelete?: boolean;
+	getLayerIndex: (id: string) => number;
 }
 
 const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
@@ -43,6 +44,7 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 			isCustomizing = false,
 			initialTemplate,
 			allowDelete = true,
+			getLayerIndex,
 		},
 		ref,
 	) => {
@@ -117,6 +119,7 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 				texts: [],
 				shapes: [],
 				lines: [],
+				layer: [],
 			});
 		}, [
 			initialTemplate,
@@ -241,6 +244,8 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 							constrainToCanvas={constrainToCanvas}
 							canvasWidth={template.width}
 							canvasHeight={template.height}
+							layerIndex={getLayerIndex(shape.id)}
+							isPreview={!allowDelete}
 						/>
 					))}
 
@@ -268,6 +273,8 @@ const EditorCanvas = forwardRef<HTMLDivElement, EditorCanvasProps>(
 							}
 							canvasWidth={template.width}
 							canvasHeight={template.height}
+							layerIndex={getLayerIndex(line.id)}
+							isPreview={!allowDelete}
 						/>
 					))}
 					<div className="absolute -bottom-8 w-full text-center text-xs text-gray-500 flex items-center justify-center">

--- a/src/features/editor/components/tabs/creator/shapes-lines-tab.tsx
+++ b/src/features/editor/components/tabs/creator/shapes-lines-tab.tsx
@@ -183,7 +183,6 @@ function ShapeTabContent() {
 										<ShapeConfigurator
 											shape={shape}
 											onUpdate={(updates) => updateShape(shape.id, updates)}
-											totalElement={totalElements}
 										/>
 									</AccordionContent>
 								</div>

--- a/src/features/editor/components/template-elements/template-line.tsx
+++ b/src/features/editor/components/template-elements/template-line.tsx
@@ -159,7 +159,7 @@ export default function TemplateLine(props: Props) {
 				width: `${Math.abs(dx) * scale}px`,
 				height: `${strokeWidth * scale}px`,
 				pointerEvents: "none",
-				zIndex: props.element.zIndex || 1,
+				zIndex: props.layerIndex,
 			}}
 		>
 			<svg

--- a/src/features/editor/components/template-elements/template-shape.tsx
+++ b/src/features/editor/components/template-elements/template-shape.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/shared/lib/utils";
 import type { ShapeElement } from "@/shared/types/element/shape";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useElementTransform } from "../../hooks/use-element-transform";
 
 interface Props extends TemplateElementBaseProps {
@@ -29,6 +28,7 @@ export interface TemplateElementBaseProps {
 	) => { x: number; y: number };
 	canvasWidth: number;
 	canvasHeight: number;
+	layerIndex: number;
 }
 
 export default function TemplateShape(props: Props) {
@@ -92,7 +92,7 @@ export default function TemplateShape(props: Props) {
 				width: scaledWidth,
 				height: scaledHeight,
 				pointerEvents: props.isPreview ? "none" : "auto",
-				zIndex: props.element.zIndex || 1,
+				zIndex: props.layerIndex,
 			}}
 		>
 			<div className="w-full h-full">

--- a/src/features/editor/containers/template-creator.tsx
+++ b/src/features/editor/containers/template-creator.tsx
@@ -73,8 +73,13 @@ export default function TemplateCreator({
 }
 
 const CanvasArea = forwardRef<HTMLDivElement>((_, ref) => {
-	const { template, setTemplate, activeElement, setActiveElement } =
-		useTemplateContext();
+	const {
+		template,
+		setTemplate,
+		activeElement,
+		setActiveElement,
+		getLayerIndex,
+	} = useTemplateContext();
 
 	const { scale, zoomIn, zoomOut, resetZoom } = useCanvasScale(
 		ref as React.RefObject<HTMLDivElement>,
@@ -102,6 +107,7 @@ const CanvasArea = forwardRef<HTMLDivElement>((_, ref) => {
 					setActiveElement={setActiveElement}
 					scale={scale}
 					isCustomizing={true}
+					getLayerIndex={getLayerIndex}
 				/>
 			</div>
 

--- a/src/features/editor/containers/template-editor.tsx
+++ b/src/features/editor/containers/template-editor.tsx
@@ -25,8 +25,8 @@ import { useIsMobile } from "@/shared/hooks/use-mobile";
 import { getTemplateForSize } from "@/shared/lib/template";
 import type { OrderProductVariant } from "@/shared/types";
 import type { TemplateData } from "@/shared/types/template";
-import { ImageUpscale } from "lucide-react";
 import html2canvas from "html2canvas-pro";
+import { ImageUpscale } from "lucide-react";
 import { useRouter } from "next/navigation";
 import {
 	createContext,
@@ -145,6 +145,7 @@ export default function TemplateEditor({
 								setActiveElement={editor.setActiveElement}
 								scale={1} // Always pass 1, scale is handled by CSS transform
 								allowDelete={false}
+								getLayerIndex={editor.getLayerIndex}
 							/>
 						</div>
 

--- a/src/features/editor/containers/template-selector.tsx
+++ b/src/features/editor/containers/template-selector.tsx
@@ -119,7 +119,7 @@ export default function TemplateSelector() {
 				))}
 
 				{/* Shapes */}
-				{scaledTemplate.shapes.map((shape) => (
+				{/* {scaledTemplate.shapes.map((shape) => (
 					<TemplateShape
 						key={shape.id}
 						isPreview
@@ -130,10 +130,10 @@ export default function TemplateSelector() {
 						canvasWidth={scaledTemplate.width}
 						canvasHeight={scaledTemplate.height}
 					/>
-				))}
+				))} */}
 
 				{/* Lines */}
-				{scaledTemplate.lines.map((line) => (
+				{/* {scaledTemplate.lines.map((line) => (
 					<TemplateLine
 						isPreview
 						key={line.id}
@@ -145,7 +145,7 @@ export default function TemplateSelector() {
 						canvasHeight={scaledTemplate.height}
 						onUpdate={() => {}}
 					/>
-				))}
+				))} */}
 			</div>
 		);
 	};

--- a/src/features/editor/hooks/use-template-editor.ts
+++ b/src/features/editor/hooks/use-template-editor.ts
@@ -23,6 +23,7 @@ export function useTemplateEditor(initial?: TemplateData) {
 			texts: [],
 			shapes: [],
 			lines: [],
+			layer: [],
 		},
 	);
 
@@ -39,6 +40,55 @@ export function useTemplateEditor(initial?: TemplateData) {
 			template.images.length,
 		],
 	);
+
+	const bringForwardLayer = (id: string) => {
+		const index = template.layer.findIndex((l) => l === id);
+		if (index === -1 || index === template.layer.length - 1) return;
+		const reordered = [...template.layer];
+		[reordered[index], reordered[index + 1]] = [
+			reordered[index + 1],
+			reordered[index],
+		];
+		setTemplate((p) => ({ ...p, layer: reordered }));
+	};
+
+	const bringToFrontLayer = (id: string) => {
+		const index = template.layer.findIndex((l) => l === id);
+		if (index === -1 || index === template.layer.length - 1) return;
+		const reordered = [...template.layer];
+		const [target] = reordered.splice(index, 1);
+		reordered.push(target);
+		setTemplate((p) => ({ ...p, layer: reordered }));
+	};
+
+	const sendBackwardLayer = (id: string) => {
+		const index = template.layer.findIndex((l) => l === id);
+		if (index <= 0) return;
+		const reordered = [...template.layer];
+		[reordered[index], reordered[index - 1]] = [
+			reordered[index - 1],
+			reordered[index],
+		];
+		setTemplate((p) => ({ ...p, layer: reordered }));
+	};
+
+	const sendToBackLayer = (id: string) => {
+		const index = template.layer.findIndex((l) => l === id);
+		if (index <= 0) return;
+		const reordered = [...template.layer];
+		const [target] = reordered.splice(index, 1);
+		reordered.unshift(target);
+		setTemplate((p) => ({ ...p, layer: reordered }));
+	};
+
+	const getLayerIndex = (id: string) =>
+		template.layer.findIndex((l) => l === id);
+
+	const getLayerLength = () => template.layer.length;
+
+	const isOnTopLayer = (id: string) =>
+		getLayerIndex(id) === getLayerLength() - 1;
+	const isOnBottomLayer = (id: string) => getLayerIndex(id) === 0;
 
 	const [activeElement, setActiveElement] = useState<string | null>(null);
 
@@ -105,7 +155,7 @@ export function useTemplateEditor(initial?: TemplateData) {
 
 		setTemplate((p) => {
 			console.log(p);
-			return { ...p, shapes: [...p.shapes, shape] };
+			return { ...p, shapes: [...p.shapes, shape], layer: [...p.layer, id] };
 		});
 		setActiveElement(id);
 		return id;
@@ -122,7 +172,22 @@ export function useTemplateEditor(initial?: TemplateData) {
 		const line: LineElement = getLineConfig(type);
 		setTemplate((p) => ({
 			...p,
-			lines: [...p.lines, line],
+			lines: [
+				...p.lines,
+				{
+					...line,
+					id,
+					startPoint: {
+						x: template.width / 2 - 100,
+						y: template.height / 2 - 100,
+					},
+					endPoint: {
+						x: template.width / 2 + 100,
+						y: template.height / 2 + 100,
+					},
+				},
+			],
+			layer: [...p.layer, id],
 		}));
 		setActiveElement(id);
 		return id;
@@ -246,6 +311,17 @@ export function useTemplateEditor(initial?: TemplateData) {
 		updateImage,
 		updateText,
 		changePrintSize,
+
+		// Layer
+		bringForwardLayer,
+		sendBackwardLayer,
+		bringToFrontLayer,
+		sendToBackLayer,
+		getLayerIndex,
+		getLayerLength,
+		isOnTopLayer,
+		isOnBottomLayer,
+
 		bringForward,
 		sendBackward,
 		bringToFront,

--- a/src/features/templates/components/list-templates.tsx
+++ b/src/features/templates/components/list-templates.tsx
@@ -1,3 +1,5 @@
+import TemplateLine from "@/features/editor/components/template-elements/template-line";
+import TemplateShape from "@/features/editor/components/template-elements/template-shape";
 import { Button } from "@/shared/components/ui/button";
 import { getTemplateForSize } from "@/shared/lib/template";
 import { cn } from "@/shared/lib/utils";
@@ -232,6 +234,35 @@ const renderTemplatePreview = (
 					}}
 				/>
 			))}
+
+			{/* Shapes */}
+			{/* {scaledTemplate.shapes.map((shape) => (
+				<TemplateShape
+					key={shape.id}
+					isPreview
+					scale={scale}
+					element={shape}
+					isElementActive={false}
+					toggleActive={() => {}}
+					canvasWidth={scaledTemplate.width}
+					canvasHeight={scaledTemplate.height}
+				/>
+			))} */}
+
+			{/* Lines */}
+			{/* {scaledTemplate.lines.map((line) => (
+				<TemplateLine
+					isPreview
+					key={line.id}
+					scale={scale}
+					element={line}
+					isElementActive={false}
+					toggleActive={() => {}}
+					canvasWidth={scaledTemplate.width}
+					canvasHeight={scaledTemplate.height}
+					onUpdate={() => {}}
+				/>
+			))} */}
 		</div>
 	);
 };

--- a/src/shared/components/shape-lines/configurator/ShapeConfigurator.tsx
+++ b/src/shared/components/shape-lines/configurator/ShapeConfigurator.tsx
@@ -1,3 +1,4 @@
+import { useTemplateContext } from "@/features/editor/containers/template-creator";
 import type { LineElement } from "@/shared/types/element/line";
 import type { ShapeElement } from "@/shared/types/element/shape";
 import type { ImageElement, TextElement } from "@/shared/types/template";
@@ -22,11 +23,9 @@ import {
 export default function ShapeConfigurator({
 	shape,
 	onUpdate,
-	totalElement,
 }: {
 	shape: ShapeElement;
 	onUpdate: (updates: Partial<ShapeElement>) => void;
-	totalElement: number;
 }) {
 	return (
 		<div className="space-y-4">
@@ -77,7 +76,6 @@ export default function ShapeConfigurator({
 			<ZIndexControls
 				element={shape}
 				onUpdate={(zIndex) => onUpdate({ zIndex })}
-				totalElement={totalElement}
 			/>
 		</div>
 	);
@@ -86,35 +84,23 @@ export default function ShapeConfigurator({
 export function ZIndexControls({
 	element,
 	onUpdate,
-	totalElement,
 }: {
 	element: LineElement | ShapeElement | ImageElement | TextElement;
 	onUpdate: (updates: number) => void;
-	totalElement: number;
 }) {
+	const {
+		bringForwardLayer,
+		sendBackwardLayer,
+		bringToFrontLayer,
+		sendToBackLayer,
+		getLayerIndex,
+		getLayerLength,
+		isOnTopLayer,
+		isOnBottomLayer,
+	} = useTemplateContext();
 	// normalize zIndex for backward compatibility
-	const currentZIndex = element.zIndex ?? 1;
-
-	const bringForward = () => {
-		if (currentZIndex >= totalElement) return;
-		onUpdate(currentZIndex + 1);
-	};
-
-	const sendBackward = () => {
-		if (currentZIndex <= 1) return;
-		onUpdate(currentZIndex - 1);
-	};
-
-	const bringToFront = () => {
-		if (currentZIndex === totalElement) return;
-		onUpdate(totalElement);
-	};
-
-	const sendToBack = () => {
-		if (currentZIndex === 1) return;
-		onUpdate(1);
-	};
-
+	const currentZIndex = getLayerIndex(element.id);
+	const totalElement = getLayerLength();
 	return (
 		<div>
 			<Label className="text-xs font-medium">Z Index</Label>
@@ -123,10 +109,10 @@ export function ZIndexControls({
 					variant="outline"
 					size="sm"
 					className="h-7 text-xs"
-					disabled={currentZIndex >= totalElement}
+					disabled={isOnTopLayer(element.id)}
 					onClick={(e) => {
 						e.stopPropagation();
-						bringForward();
+						bringForwardLayer(element.id);
 					}}
 				>
 					<ArrowUp className="w-4 h-4 mr-1" />
@@ -136,10 +122,10 @@ export function ZIndexControls({
 					variant="outline"
 					size="sm"
 					className="h-7 text-xs"
-					disabled={currentZIndex <= 1}
+					disabled={isOnBottomLayer(element.id)}
 					onClick={(e) => {
 						e.stopPropagation();
-						sendBackward();
+						sendBackwardLayer(element.id);
 					}}
 				>
 					<ArrowDown className="w-4 h-4 mr-1" />
@@ -149,26 +135,26 @@ export function ZIndexControls({
 					variant="outline"
 					size="sm"
 					className="h-7 text-xs"
-					disabled={currentZIndex >= totalElement}
+					disabled={isOnTopLayer(element.id)}
 					onClick={(e) => {
 						e.stopPropagation();
-						bringToFront();
+						bringToFrontLayer(element.id);
 					}}
 				>
-					<ArrowUp className="w-4 h-4 mr-1" />
+					<ArrowUpToLine className="w-4 h-4 mr-1" />
 					To Front
 				</Button>
 				<Button
 					variant="outline"
 					size="sm"
 					className="h-7 text-xs"
-					disabled={currentZIndex <= 1}
+					disabled={isOnBottomLayer(element.id)}
 					onClick={(e) => {
 						e.stopPropagation();
-						sendToBack();
+						sendToBackLayer(element.id);
 					}}
 				>
-					<ArrowDown className="w-4 h-4 mr-1" />
+					<ArrowDownToLine className="w-4 h-4 mr-1" />
 					To Back
 				</Button>
 			</div>

--- a/src/shared/components/shape-lines/variants.tsx
+++ b/src/shared/components/shape-lines/variants.tsx
@@ -87,7 +87,6 @@ export const lineVariants: LineVariant[] = [
 		preview: (
 			<div className="flex items-center">
 				<div className="w-10 h-0.5 bg-gray-700" />
-				<div className="w-0 h-0 border-l-[6px] border-l-gray-700 border-t-[3px] border-t-transparent border-b-[3px] border-b-transparent" />
 			</div>
 		),
 	},

--- a/src/shared/repository/templates/action.ts
+++ b/src/shared/repository/templates/action.ts
@@ -69,6 +69,12 @@ export const getTemplates = async (query?: {
 			texts: template.data?.texts || [],
 			shapes: template.data?.shapes || [],
 			lines: template.data?.lines || [],
+			layer: template.data?.layer || [
+				...template.data.images.map((i) => i.id),
+				...template.data.texts.map((t) => t.id),
+				...(template.data?.shapes?.map((s) => s.id) || []),
+				...(template.data?.lines?.map((l) => l.id) || []),
+			],
 		};
 	});
 
@@ -127,6 +133,12 @@ export const getTemplateById = async (id: TemplateEntity["id"]) => {
 		texts: templates[0].data?.texts || [],
 		shapes: templates[0].data?.shapes || [],
 		lines: templates[0].data?.lines || [],
+		layer: templates[0].data?.layer || [
+			...templates[0].data.images.map((i) => i.id),
+			...templates[0].data.texts.map((t) => t.id),
+			...(templates[0].data?.shapes?.map((s) => s.id) || []),
+			...(templates[0].data?.lines?.map((l) => l.id) || []),
+		],
 	};
 
 	return {
@@ -148,6 +160,7 @@ export const createTemplate = async (req: CreateTemplateRequest) => {
 		texts: req.texts,
 		shapes: req.shapes,
 		lines: req.lines,
+		layer: req.layer,
 	};
 
 	const queryBuilder = sql`

--- a/src/shared/types/template.ts
+++ b/src/shared/types/template.ts
@@ -81,6 +81,7 @@ export interface TemplateData {
 	texts: TextElement[];
 	shapes: ShapeElement[];
 	lines: LineElement[];
+	layer: string[];
 }
 
 // export type PrintSize = "10x20" | "15x20" | "20x30";


### PR DESCRIPTION
This pull request introduces a new layer management system for template elements in the editor, replacing the previous z-index approach. The changes allow users to control the stacking order of shapes and lines using layer operations (bring forward/backward, bring to front/back), and update the UI and hooks to support this. Additionally, the configurator UI is refactored to use the new layer system, and unused z-index code is removed.

**Layer Management System Implementation**

* Added a `layer` array to the template data structure to track the stacking order of elements, and updated the editor initialization and element addition logic to maintain this array. [[1]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504R26) [[2]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504L108-R158) [[3]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504L125-R190)
* Implemented layer manipulation functions (`bringForwardLayer`, `sendBackwardLayer`, `bringToFrontLayer`, `sendToBackLayer`, `getLayerIndex`, etc.) in `useTemplateEditor` to control element order, and exposed them via context. [[1]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504R44-R92) [[2]](diffhunk://#diff-9d447f2f3364c18e60e204006712f5c46f8b2d0806415a259f1e1ed8ca57a504R314-R324)

**UI and Component Updates**

* Updated `EditorCanvas`, `TemplateShape`, and `TemplateLine` components to use `layerIndex` from the new layer system for rendering order, replacing the previous `zIndex` property. [[1]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3R247-R248) [[2]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3R276-R277) [[3]](diffhunk://#diff-4bbcdb92950dcfbd6e85fe4bee2c1492681c78c22f4d1355ad17b268bffcc101L162-R162) [[4]](diffhunk://#diff-c76c5f993c1684a4ad3384d1267b50f9ddfbb27591c0c2e9362733237ab07e8aL95-R95)
* Updated context and props passing in containers (`template-creator.tsx`, `template-editor.tsx`) to provide `getLayerIndex` and related functions to child components. [[1]](diffhunk://#diff-7dede26b87aceedd09861f056756a2dd6b31d363d81b62ce7d74ea0678851cd3L76-R82) [[2]](diffhunk://#diff-7dede26b87aceedd09861f056756a2dd6b31d363d81b62ce7d74ea0678851cd3R110) [[3]](diffhunk://#diff-658e2ac3b74585fd8a32599b866158e06c9dc4f56634da74e7f1b0660f9136eeR148)

**Configurator and Controls Refactor**

* Refactored `ShapeConfigurator` and `ZIndexControls` to use the new layer manipulation functions instead of direct z-index updates, and removed old z-index logic and props. [[1]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL25-L29) [[2]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL80) [[3]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL89-R103) [[4]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL126-R115) [[5]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL139-R128) [[6]](diffhunk://#diff-6717cda01c65009c9fdf0326fb0b053b3371ad740982afa5614f280f64b28aeeL152-R157)

**Code Cleanup and Consistency**

* Removed unused z-index code and props throughout the codebase, and ensured consistent use of the new layer system. [[1]](diffhunk://#diff-0aabf59e8a095d67b411cfdba33607959b858053478db66da22a6ad735fb1f63L186) [[2]](diffhunk://#diff-c76c5f993c1684a4ad3384d1267b50f9ddfbb27591c0c2e9362733237ab07e8aR31)
* Updated imports and minor formatting for consistency. [[1]](diffhunk://#diff-7632ade62be335065730d327944ce60ca8b6be1ba5633f1c998f905e878f40a3L11-R12) [[2]](diffhunk://#diff-658e2ac3b74585fd8a32599b866158e06c9dc4f56634da74e7f1b0660f9136eeL28-R29) [[3]](diffhunk://#diff-a4d9cfc734056b2badcc90c4c5b51eb9bf51910c7cc5d8c2ef084929d6c926cbR1-R2)

**Preview and Selector Adjustments**

* Temporarily commented out shape and line rendering in template previews and selectors, likely pending updates to support the new layer system. [[1]](diffhunk://#diff-b30acc055e8274f7678629e73035a2627845ffe09a43394573f751c8ac0605a7L122-R122) [[2]](diffhunk://#diff-b30acc055e8274f7678629e73035a2627845ffe09a43394573f751c8ac0605a7L133-R136) [[3]](diffhunk://#diff-b30acc055e8274f7678629e73035a2627845ffe09a43394573f751c8ac0605a7L148-R148) [[4]](diffhunk://#diff-a4d9cfc734056b2badcc90c4c5b51eb9bf51910c7cc5d8c2ef084929d6c926cbR237-R265)

These changes collectively modernize how element stacking is handled in the template editor, making it more flexible and maintainable.