### PR TITLE
Add element id to layer array when adding image and text element

### DIFF
--- a/src/features/editor/containers/template-selector.tsx
+++ b/src/features/editor/containers/template-selector.tsx
@@ -24,18 +24,33 @@ import { useGetTemplatesQuery } from "@/shared/repository/templates/query";
 import type { TemplateData } from "@/shared/types/template";
 import { PlusCircle, UserRound } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import TemplateLine from "../components/template-elements/template-line";
 import TemplateShape from "../components/template-elements/template-shape";
 
 export default function TemplateSelector() {
 	const router = useRouter();
+
+	const searchParams = useSearchParams();
+	const currentPage = Number(searchParams.get("page")) || 1;
+	const [page, setPage] = useState(currentPage);
+
 	// const [selectedSize, setSelectedSize] = useState(printSizes[1]);
-	const { data: res, isLoading, error } = useGetTemplatesQuery();
+	const { data: res, isLoading, error } = useGetTemplatesQuery({ page });
 	const session = useSessionQuery();
 	const { mutate: logout } = useLogoutMutation();
 
 	const customTemplates = res?.data?.templates || [];
+	const totalPages = res?.data?.pagination.total_page || 1;
+
+	// Keep page in sync with URL
+	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+	useEffect(() => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.set("page", page.toString());
+		router.push(`?${params.toString()}`);
+	}, [page, router]);
 
 	// const handleSizeChange = (size: string) => {
 	// 	const newSize = printSizes.find((s) => s.name === size);
@@ -266,6 +281,25 @@ export default function TemplateSelector() {
 						</CardContent>
 					</Card>
 				))}
+			</div>
+			<div className="flex justify-center items-center gap-4 mt-8">
+				<Button
+					variant="outline"
+					disabled={page <= 1}
+					onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+				>
+					Previous
+				</Button>
+				<span>
+					Page {page} of {totalPages}
+				</span>
+				<Button
+					variant="outline"
+					disabled={page >= totalPages}
+					onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+				>
+					Next
+				</Button>
 			</div>
 		</div>
 	);

--- a/src/features/editor/containers/template-selector.tsx
+++ b/src/features/editor/containers/template-selector.tsx
@@ -42,7 +42,7 @@ export default function TemplateSelector() {
 	const { mutate: logout } = useLogoutMutation();
 
 	const customTemplates = res?.data?.templates || [];
-	const totalPages = res?.data?.pagination.total_page || 1;
+	const totalPages = Number(res?.data?.pagination?.total_page) || 1;
 
 	// Keep page in sync with URL
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
@@ -51,6 +51,11 @@ export default function TemplateSelector() {
 		params.set("page", page.toString());
 		router.push(`?${params.toString()}`);
 	}, [page, router]);
+
+	useEffect(() => {
+		const next = Number(searchParams.get("page")) || 1;
+		setPage((prev) => (prev !== next ? next : prev));
+	}, [searchParams]);
 
 	// const handleSizeChange = (size: string) => {
 	// 	const newSize = printSizes.find((s) => s.name === size);

--- a/src/features/editor/hooks/use-template-editor.ts
+++ b/src/features/editor/hooks/use-template-editor.ts
@@ -108,7 +108,11 @@ export function useTemplateEditor(initial?: TemplateData) {
 			height: 200,
 			draggable: true,
 		};
-		setTemplate((p) => ({ ...p, images: [...p.images, img] }));
+		setTemplate((p) => ({
+			...p,
+			images: [...p.images, img],
+			layer: [...p.layer, id],
+		}));
 		setActiveElement(id);
 		return id;
 	};
@@ -133,7 +137,11 @@ export function useTemplateEditor(initial?: TemplateData) {
 				lineHeight: "1.2",
 			},
 		};
-		setTemplate((p) => ({ ...p, texts: [...p.texts, txt] }));
+		setTemplate((p) => ({
+			...p,
+			texts: [...p.texts, txt],
+			layer: [...p.layer, id],
+		}));
 		setActiveElement(id);
 		return id;
 	};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to the template selector with Previous/Next controls and a “Page X of Y” indicator. The current page syncs with the URL for easy navigation, bookmarking, and sharing.

* **Bug Fixes**
  * Adding images and text now correctly updates layer order so elements stack and behave consistently with other content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->