### PR TITLE
Fix template image element

### DIFF
--- a/src/features/editor/components/template-elements/crop-modal.tsx
+++ b/src/features/editor/components/template-elements/crop-modal.tsx
@@ -1,0 +1,228 @@
+import type { CropArea, ImageElement } from "@/shared/types";
+import { createPortal } from "react-dom";
+
+export const CropModal = ({
+	isOpen,
+	onClose,
+	image,
+	originalDimensions,
+	cropArea,
+	setCropArea,
+	applyCrop,
+	onCropMouseDown,
+	onCropResizeMouseDown,
+}: {
+	isOpen: boolean;
+	onClose: () => void;
+	image: ImageElement;
+	originalDimensions: { width: number; height: number };
+	cropArea: CropArea;
+	setCropArea: (area: CropArea) => void;
+	applyCrop: () => void;
+	onCropMouseDown: (e: React.MouseEvent) => void;
+	onCropResizeMouseDown: (e: React.MouseEvent, direction: string) => void;
+}) => {
+	if (!isOpen) return null;
+
+	// Calculate optimal modal size - now we can use full viewport
+	const maxModalWidth = Math.min(window.innerWidth * 0.95, 1200);
+	const maxModalHeight = Math.min(window.innerHeight * 0.95, 800);
+
+	// Calculate image display scale for larger display
+	const headerHeight = 80;
+	const footerHeight = 60;
+	const padding = 0;
+	const availableWidth = maxModalWidth - padding;
+	const availableHeight =
+		maxModalHeight - headerHeight - footerHeight - padding;
+
+	const scaleX = availableWidth / originalDimensions.width;
+	const scaleY = availableHeight / originalDimensions.height;
+	const imageDisplayScale = Math.min(scaleX, scaleY, 1); // Allow up to 1.5x scaling
+
+	const displayWidth = originalDimensions.width * imageDisplayScale;
+	const displayHeight = originalDimensions.height * imageDisplayScale;
+
+	const modalWidth = Math.min(displayWidth + padding, maxModalWidth);
+	const modalHeight = Math.min(
+		displayHeight + headerHeight + footerHeight + padding,
+		maxModalHeight,
+	);
+
+	return createPortal(
+		<>
+			{/* Backdrop */}
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
+			<div
+				className="fixed inset-0 bg-black bg-opacity-20 z-[9998] backdrop-blur-sm"
+				onClick={onClose}
+			/>
+
+			{/* Crop Modal */}
+			<div
+				className="fixed z-[9999] bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden"
+				style={{
+					left: "50%",
+					top: "50%",
+					transform: "translate(-50%, -50%)",
+					width: modalWidth,
+					height: modalHeight,
+					maxWidth: "95vw",
+					maxHeight: "95vh",
+				}}
+			>
+				{/* Header */}
+				<div className="flex justify-between items-center px-6 py-4 border-b border-gray-200 bg-gray-50">
+					<div>
+						<h3 className="text-gray-900 font-semibold text-lg">
+							Adjust Image Crop
+						</h3>
+						<p className="text-sm text-gray-600 mt-1">
+							Drag to move • Resize corners to adjust • Target: {image.width} ×{" "}
+							{image.height}px
+						</p>
+					</div>
+					<div className="flex gap-3">
+						<button
+							type="button"
+							onClick={onClose}
+							className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={applyCrop}
+							className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+						>
+							Apply Crop
+						</button>
+					</div>
+				</div>
+
+				{/* Image container with crop overlay */}
+				<div className="flex-1 flex items-center justify-center  bg-gray-100">
+					<div
+						className="relative bg-white rounded-lg shadow-inner overflow-hidden"
+						style={{
+							width: displayWidth,
+							height: displayHeight,
+							maxWidth: availableWidth,
+							maxHeight: availableHeight,
+						}}
+					>
+						<img
+							src={
+								image.src ||
+								"https://images.unsplash.com/photo-1501594907352-04cda38ebc29"
+							}
+							alt="Crop preview"
+							className="w-full h-full object-contain select-none"
+							draggable={false}
+							style={{
+								width: displayWidth,
+								height: displayHeight,
+							}}
+						/>
+
+						{/* Crop overlay with dark areas */}
+						<div className="absolute inset-0">
+							{/* Dark overlays */}
+							<div
+								className="absolute bg-black/40"
+								style={{
+									left: 0,
+									top: 0,
+									right: 0,
+									height: cropArea.y * imageDisplayScale,
+								}}
+							/>
+							<div
+								className="absolute bg-black/40"
+								style={{
+									left: 0,
+									top: (cropArea.y + cropArea.height) * imageDisplayScale,
+									right: 0,
+									bottom: 0,
+								}}
+							/>
+							<div
+								className="absolute bg-black/40"
+								style={{
+									left: 0,
+									top: cropArea.y * imageDisplayScale,
+									width: cropArea.x * imageDisplayScale,
+									height: cropArea.height * imageDisplayScale,
+								}}
+							/>
+							<div
+								className="absolute bg-black/40"
+								style={{
+									left: (cropArea.x + cropArea.width) * imageDisplayScale,
+									top: cropArea.y * imageDisplayScale,
+									right: 0,
+									height: cropArea.height * imageDisplayScale,
+								}}
+							/>
+
+							{/* Crop selection area */}
+							<div
+								className="absolute border-2 border-blue-500 cursor-move shadow-lg"
+								style={{
+									left: cropArea.x * imageDisplayScale,
+									top: cropArea.y * imageDisplayScale,
+									width: cropArea.width * imageDisplayScale,
+									height: cropArea.height * imageDisplayScale,
+									backgroundColor: "transparent",
+									boxShadow:
+										"0 0 0 1px rgba(255,255,255,0.5), 0 4px 12px rgba(0,0,0,0.15)",
+								}}
+								onMouseDown={onCropMouseDown}
+							>
+								{/* Corner resize handles */}
+								<div
+									className="absolute -top-2 -left-2 w-5 h-5 bg-white border-2 border-blue-500 rounded-full shadow-md cursor-nw-resize hover:bg-blue-50 transition-colors"
+									onMouseDown={(e) => onCropResizeMouseDown(e, "nw")}
+								/>
+								<div
+									className="absolute -top-2 -right-2 w-5 h-5 bg-white border-2 border-blue-500 rounded-full shadow-md cursor-ne-resize hover:bg-blue-50 transition-colors"
+									onMouseDown={(e) => onCropResizeMouseDown(e, "ne")}
+								/>
+								<div
+									className="absolute -bottom-2 -left-2 w-5 h-5 bg-white border-2 border-blue-500 rounded-full shadow-md cursor-sw-resize hover:bg-blue-50 transition-colors"
+									onMouseDown={(e) => onCropResizeMouseDown(e, "sw")}
+								/>
+								<div
+									className="absolute -bottom-2 -right-2 w-5 h-5 bg-white border-2 border-blue-500 rounded-full shadow-md cursor-se-resize hover:bg-blue-50 transition-colors"
+									onMouseDown={(e) => onCropResizeMouseDown(e, "se")}
+								/>
+
+								{/* Grid lines for rule of thirds */}
+								<div className="absolute inset-0 pointer-events-none">
+									<div className="absolute left-1/3 top-0 bottom-0 w-px bg-white opacity-60" />
+									<div className="absolute left-2/3 top-0 bottom-0 w-px bg-white opacity-60" />
+									<div className="absolute top-1/3 left-0 right-0 h-px bg-white opacity-60" />
+									<div className="absolute top-2/3 left-0 right-0 h-px bg-white opacity-60" />
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Footer with crop info */}
+				<div className="px-6 py-3 border-t border-gray-200 bg-gray-50">
+					<div className="flex justify-between items-center text-sm text-gray-600">
+						<div>
+							Crop area: {Math.round(cropArea.width)} ×{" "}
+							{Math.round(cropArea.height)}px
+						</div>
+						<div>
+							Position: {Math.round(cropArea.x)}, {Math.round(cropArea.y)}
+						</div>
+					</div>
+				</div>
+			</div>
+		</>,
+		document.body,
+	);
+};

--- a/src/features/editor/components/template-elements/template-image.tsx
+++ b/src/features/editor/components/template-elements/template-image.tsx
@@ -197,13 +197,13 @@ export default function TemplateImage({
 	const getImageStyle = (): React.CSSProperties => {
 		const clipPath = getClipPath();
 		const imageOffset = image.imageOffset || { x: 0, y: 0 };
-		const scaleX = image.scaleX || 1;
-		const scaleY = image.scaleY || 1;
+		const scaleX = (image.scaleX || 1) * scale;
+		const scaleY = (image.scaleY || 1) * scale;
 
 		return {
 			clipPath,
 			filter: image.grayscale ? "grayscale(1)" : "none",
-			transform: `translate(${imageOffset.x}px, ${imageOffset.y}px) scale(${scaleX}, ${scaleY})`,
+			transform: `translate(${imageOffset.x * scale}px, ${imageOffset.y * scale}px) scale(${scaleX}, ${scaleY})`,
 			transformOrigin: "0 0",
 			width: originalDimensions?.width || "auto",
 			height: originalDimensions?.height || "auto",
@@ -217,15 +217,15 @@ export default function TemplateImage({
 	const getClipPath = () => {
 		if (!canvasWidth || !canvasHeight) return undefined;
 
-		const imgX = image.position.x;
-		const imgY = image.position.y;
-		const imgW = image.width;
-		const imgH = image.height;
+		const imgX = image.position.x * scale;
+		const imgY = image.position.y * scale;
+		const imgW = image.width * scale;
+		const imgH = image.height * scale;
 
 		const clipLeft = Math.max(0, -imgX);
 		const clipTop = Math.max(0, -imgY);
-		const clipRight = Math.min(imgW, canvasWidth - imgX);
-		const clipBottom = Math.min(imgH, canvasHeight - imgY);
+		const clipRight = Math.min(imgW, canvasWidth * scale - imgX);
+		const clipBottom = Math.min(imgH, canvasHeight * scale - imgY);
 
 		if (clipRight <= clipLeft || clipBottom <= clipTop) {
 			return "inset(100% 100% 100% 100%)";

--- a/src/features/editor/components/template-elements/template-image.tsx
+++ b/src/features/editor/components/template-elements/template-image.tsx
@@ -1,6 +1,7 @@
 import type { CropArea, ImageElement } from "@/shared/types/template";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type React from "react";
+import { CropModal } from "./crop-modal";
 
 interface TemplateImageProps {
 	image: ImageElement;
@@ -721,167 +722,17 @@ export default function TemplateImage({
 
 			{/* Crop Overlay Modal */}
 			{isCropMode && originalDimensions && (
-				<>
-					{/* Backdrop */}
-					{/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
-					<div
-						className="fixed inset-0 bg-black bg-opacity-50 z-40"
-						onClick={() => setIsCropMode(false)}
-					/>
-
-					{/* Crop Modal */}
-					<div
-						className="fixed z-50 bg-white rounded-lg shadow-editor-modal border-2 border-border"
-						style={{
-							left: "50%",
-							top: "50%",
-							transform: "translate(-50%, -50%)",
-							width: Math.min(
-								originalDimensions.width * imageDisplayScale + 60,
-								window.innerWidth * 0.9,
-							),
-							height: Math.min(
-								originalDimensions.height * imageDisplayScale + 100,
-								window.innerHeight * 0.9,
-							),
-							maxWidth: "90vw",
-							maxHeight: "90vh",
-						}}
-					>
-						{/* Header */}
-						<div className="flex justify-between items-center p-4 border-b border-border">
-							<h3 className="text-foreground font-medium text-lg">
-								Adjust Crop
-							</h3>
-							<div className="flex gap-2">
-								<button
-									type="button"
-									onClick={() => setIsCropMode(false)}
-									className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 transition-colors"
-								>
-									Cancel
-								</button>
-								<button
-									type="button"
-									onClick={applyCrop}
-									className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
-								>
-									Apply
-								</button>
-							</div>
-						</div>
-
-						{/* Image container with crop overlay */}
-						<div className="p-4">
-							<div
-								className="relative mx-auto overflow-hidden bg-editor-canvas rounded"
-								style={{
-									width: Math.min(
-										originalDimensions.width * imageDisplayScale,
-										window.innerWidth * 0.8,
-									),
-									height: Math.min(
-										originalDimensions.height * imageDisplayScale,
-										window.innerHeight * 0.7,
-									),
-								}}
-							>
-								<img
-									src={
-										image.src ||
-										"https://images.unsplash.com/photo-1501594907352-04cda38ebc29"
-									}
-									alt="Crop preview"
-									className="w-full h-full object-contain select-none"
-									draggable={false}
-								/>
-
-								{/* Crop overlay with dark areas */}
-								<div className="absolute inset-0">
-									{/* Dark overlays */}
-									<div
-										className="absolute bg-editor-crop-overlay bg-opacity-60"
-										style={{
-											left: 0,
-											top: 0,
-											right: 0,
-											height: cropArea.y * imageDisplayScale,
-										}}
-									/>
-									<div
-										className="absolute bg-editor-crop-overlay bg-opacity-60"
-										style={{
-											left: 0,
-											top: (cropArea.y + cropArea.height) * imageDisplayScale,
-											right: 0,
-											bottom: 0,
-										}}
-									/>
-									<div
-										className="absolute bg-editor-crop-overlay bg-opacity-60"
-										style={{
-											left: 0,
-											top: cropArea.y * imageDisplayScale,
-											width: cropArea.x * imageDisplayScale,
-											height: cropArea.height * imageDisplayScale,
-										}}
-									/>
-									<div
-										className="absolute bg-editor-crop-overlay bg-opacity-60"
-										style={{
-											left: (cropArea.x + cropArea.width) * imageDisplayScale,
-											top: cropArea.y * imageDisplayScale,
-											right: 0,
-											height: cropArea.height * imageDisplayScale,
-										}}
-									/>
-
-									{/* Crop selection area */}
-									<div
-										className="absolute border-2 border-editor-crop-area cursor-move"
-										style={{
-											left: cropArea.x * imageDisplayScale,
-											top: cropArea.y * imageDisplayScale,
-											width: cropArea.width * imageDisplayScale,
-											height: cropArea.height * imageDisplayScale,
-											backgroundColor: "transparent",
-										}}
-										onMouseDown={handleCropMouseDown}
-									>
-										<div
-											className="absolute -top-2 -left-2 w-4 h-4 bg-white border-2 border-blue-500 rounded-full shadow cursor-nw-resize"
-											onMouseDown={(e) => handleCropResizeMouseDown(e, "nw")}
-										/>
-										<div
-											className="absolute -top-2 -right-2 w-4 h-4 bg-white border-2 border-blue-500 rounded-full shadow cursor-ne-resize"
-											onMouseDown={(e) => handleCropResizeMouseDown(e, "ne")}
-										/>
-										<div
-											className="absolute -bottom-2 -left-2 w-4 h-4 bg-white border-2 border-blue-500 rounded-full shadow cursor-sw-resize"
-											onMouseDown={(e) => handleCropResizeMouseDown(e, "sw")}
-										/>
-										<div
-											className="absolute -bottom-2 -right-2 w-4 h-4 bg-white border-2 border-blue-500 rounded-full shadow cursor-se-resize"
-											onMouseDown={(e) => handleCropResizeMouseDown(e, "se")}
-										/>
-										{/* Grid lines */}
-										<div className="absolute inset-0 pointer-events-none">
-											<div className="absolute left-1/3 top-0 bottom-0 w-px bg-white opacity-70" />
-											<div className="absolute left-2/3 top-0 bottom-0 w-px bg-white opacity-70" />
-											<div className="absolute top-1/3 left-0 right-0 h-px bg-white opacity-70" />
-											<div className="absolute top-2/3 left-0 right-0 h-px bg-white opacity-70" />
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
-
-						<div className="px-4 pb-4 text-center text-muted-foreground text-sm">
-							Double-click image to crop • Target size: {image.width} ×{" "}
-							{image.height}px
-						</div>
-					</div>
-				</>
+				<CropModal
+					isOpen={isCropMode}
+					onClose={cancelCrop}
+					image={image}
+					originalDimensions={originalDimensions}
+					cropArea={cropArea}
+					setCropArea={setCropArea}
+					applyCrop={applyCrop}
+					onCropMouseDown={handleCropMouseDown}
+					onCropResizeMouseDown={handleCropResizeMouseDown}
+				/>
 			)}
 		</>
 	);

--- a/src/features/editor/components/template-elements/template-image.tsx
+++ b/src/features/editor/components/template-elements/template-image.tsx
@@ -621,7 +621,7 @@ export default function TemplateImage({
 			{/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
 			<div
 				ref={dropZoneRef}
-				className={`absolute overflow-hidden transition-all duration-200 ${
+				className={`absolute overflow-hidden ${
 					isActive ? "ring-2 ring-editor-selection shadow-editor-element" : ""
 				} ${isDragOver ? "ring-2 ring-primary" : ""}`}
 				style={{

--- a/src/features/editor/hooks/use-adjust-image.ts
+++ b/src/features/editor/hooks/use-adjust-image.ts
@@ -1,37 +1,231 @@
-"use client";
-
-import type { ImageElement, TemplateData } from "@/shared/types/template";
+import type { TemplateData } from "@/shared/types/template";
 import { useCallback } from "react";
 
 interface UseImageAdjustProps {
 	template: TemplateData;
-	setTemplate: (template: TemplateData) => void;
+	setTemplate: React.Dispatch<React.SetStateAction<TemplateData>>;
 }
 
 export function useImageAdjust({ template, setTemplate }: UseImageAdjustProps) {
 	const handleImageAdjust = useCallback(
-		(e: CustomEvent) => {
-			const { id, imageOffset, imageScale, rotate } = e.detail;
+		(event: CustomEvent) => {
+			const { id, imageOffset, scaleX, scaleY, fit } = event.detail;
 
-			setTemplate({
-				...template,
-				images: template.images.map((img) =>
-					img.id === id
-						? {
-								...img,
-								imageOffset: imageOffset || img.imageOffset,
-								imageScale:
-									imageScale !== undefined ? imageScale : img.imageScale,
-								rotate: rotate !== undefined ? rotate : img.rotate,
-							}
-						: img,
-				),
+			setTemplate((prevTemplate) => {
+				const imageIndex = prevTemplate.images.findIndex(
+					(img) => img.id === id,
+				);
+				if (imageIndex === -1) return prevTemplate;
+
+				const updatedImages = [...prevTemplate.images];
+				const currentImage = updatedImages[imageIndex];
+
+				// Update the image with new offset and scale
+				updatedImages[imageIndex] = {
+					...currentImage,
+					imageOffset: imageOffset ?? currentImage.imageOffset,
+					scaleX: scaleX ?? currentImage.scaleX ?? 1,
+					scaleY: scaleY ?? currentImage.scaleY ?? 1,
+				};
+
+				return {
+					...prevTemplate,
+					images: updatedImages,
+				};
 			});
 		},
-		[template, setTemplate],
+		[setTemplate],
+	);
+
+	// Helper function to calculate optimal fit
+	const calculateImageFit = useCallback(
+		(
+			imageId: string,
+			fitType: "cover" | "contain" | "fill" | "fit-width" | "fit-height",
+		) => {
+			const image = template.images.find((img) => img.id === imageId);
+			if (!image) return;
+
+			// You would need to get the natural dimensions of the image
+			// This could be stored when the image loads or passed as parameter
+			const naturalWidth = 800; // Replace with actual natural width
+			const naturalHeight = 600; // Replace with actual natural height
+
+			let newScaleX: number;
+			let newScaleY: number;
+			let newOffset: { x: number; y: number };
+
+			const containerAspectRatio = image.width / image.height;
+			const imageAspectRatio = naturalWidth / naturalHeight;
+
+			switch (fitType) {
+				case "cover": {
+					// Scale image to cover entire container
+					const coverScaleX = image.width / naturalWidth;
+					const coverScaleY = image.height / naturalHeight;
+					const coverScale = Math.max(coverScaleX, coverScaleY);
+					newScaleX = coverScale;
+					newScaleY = coverScale;
+
+					const coverScaledWidth = naturalWidth * coverScale;
+					const coverScaledHeight = naturalHeight * coverScale;
+
+					newOffset = {
+						x: (image.width - coverScaledWidth) / 2,
+						y: (image.height - coverScaledHeight) / 2,
+					};
+					break;
+				}
+
+				case "contain": {
+					// Scale image to fit entirely within container
+					const containScaleX = image.width / naturalWidth;
+					const containScaleY = image.height / naturalHeight;
+					const containScale = Math.min(containScaleX, containScaleY);
+					newScaleX = containScale;
+					newScaleY = containScale;
+
+					const containScaledWidth = naturalWidth * containScale;
+					const containScaledHeight = naturalHeight * containScale;
+
+					newOffset = {
+						x: (image.width - containScaledWidth) / 2,
+						y: (image.height - containScaledHeight) / 2,
+					};
+					break;
+				}
+
+				case "fill":
+					// Stretch image to fill container exactly (may distort)
+					newScaleX = image.width / naturalWidth;
+					newScaleY = image.height / naturalHeight;
+					newOffset = { x: 0, y: 0 };
+					break;
+
+				case "fit-width": {
+					// Scale to fit width, height may overflow/underflow
+					newScaleX = image.width / naturalWidth;
+					newScaleY = newScaleX; // Maintain aspect ratio
+					const fitWidthScaledHeight = naturalHeight * newScaleY;
+					newOffset = {
+						x: 0,
+						y: (image.height - fitWidthScaledHeight) / 2,
+					};
+					break;
+				}
+
+				case "fit-height": {
+					// Scale to fit height, width may overflow/underflow
+					newScaleY = image.height / naturalHeight;
+					newScaleX = newScaleY; // Maintain aspect ratio
+					const fitHeightScaledWidth = naturalWidth * newScaleX;
+					newOffset = {
+						x: (image.width - fitHeightScaledWidth) / 2,
+						y: 0,
+					};
+					break;
+				}
+
+				default:
+					return;
+			}
+
+			// Dispatch the adjustment
+			document.dispatchEvent(
+				new CustomEvent("imageAdjust", {
+					detail: {
+						id: imageId,
+						imageOffset: newOffset,
+						scaleX: newScaleX,
+						scaleY: newScaleY,
+					},
+				}),
+			);
+		},
+		[template.images],
+	);
+
+	// Helper to reset image to original state
+	const resetImage = useCallback(
+		(imageId: string) => {
+			calculateImageFit(imageId, "cover");
+		},
+		[calculateImageFit],
+	);
+
+	// Helper to zoom image
+	const zoomImage = useCallback(
+		(
+			imageId: string,
+			zoomFactorX: number,
+			zoomFactorY: number = zoomFactorX,
+			centerPoint?: { x: number; y: number },
+		) => {
+			const image = template.images.find((img) => img.id === imageId);
+			if (!image) return;
+
+			const currentScaleX = image.scaleX || 1;
+			const currentScaleY = image.scaleY || 1;
+			const currentOffset = image.imageOffset || { x: 0, y: 0 };
+			const newScaleX = Math.max(0.1, currentScaleX * zoomFactorX);
+			const newScaleY = Math.max(0.1, currentScaleY * zoomFactorY);
+
+			let newOffset = currentOffset;
+
+			// If center point is provided, zoom towards that point
+			if (centerPoint) {
+				const scaleChangeX = newScaleX / currentScaleX;
+				const scaleChangeY = newScaleY / currentScaleY;
+
+				newOffset = {
+					x: centerPoint.x - (centerPoint.x - currentOffset.x) * scaleChangeX,
+					y: centerPoint.y - (centerPoint.y - currentOffset.y) * scaleChangeY,
+				};
+			}
+
+			document.dispatchEvent(
+				new CustomEvent("imageAdjust", {
+					detail: {
+						id: imageId,
+						imageOffset: newOffset,
+						scaleX: newScaleX,
+						scaleY: newScaleY,
+					},
+				}),
+			);
+		},
+		[template.images],
+	);
+
+	// Helper to pan image
+	const panImage = useCallback(
+		(imageId: string, deltaX: number, deltaY: number) => {
+			const image = template.images.find((img) => img.id === imageId);
+			if (!image) return;
+
+			const currentOffset = image.imageOffset || { x: 0, y: 0 };
+			const newOffset = {
+				x: currentOffset.x + deltaX,
+				y: currentOffset.y + deltaY,
+			};
+
+			document.dispatchEvent(
+				new CustomEvent("imageAdjust", {
+					detail: {
+						id: imageId,
+						imageOffset: newOffset,
+					},
+				}),
+			);
+		},
+		[template.images],
 	);
 
 	return {
 		handleImageAdjust,
+		calculateImageFit,
+		resetImage,
+		zoomImage,
+		panImage,
 	};
 }

--- a/src/features/editor/hooks/use-adjust-image.ts
+++ b/src/features/editor/hooks/use-adjust-image.ts
@@ -1,4 +1,4 @@
-import type { TemplateData } from "@/shared/types/template";
+import type { ImageElement, TemplateData } from "@/shared/types/template";
 import { useCallback } from "react";
 
 interface UseImageAdjustProps {
@@ -42,14 +42,11 @@ export function useImageAdjust({ template, setTemplate }: UseImageAdjustProps) {
 		(
 			imageId: string,
 			fitType: "cover" | "contain" | "fill" | "fit-width" | "fit-height",
+			naturalWidth: number,
+			naturalHeight: number,
 		) => {
 			const image = template.images.find((img) => img.id === imageId);
 			if (!image) return;
-
-			// You would need to get the natural dimensions of the image
-			// This could be stored when the image loads or passed as parameter
-			const naturalWidth = 800; // Replace with actual natural width
-			const naturalHeight = 600; // Replace with actual natural height
 
 			let newScaleX: number;
 			let newScaleY: number;
@@ -147,8 +144,13 @@ export function useImageAdjust({ template, setTemplate }: UseImageAdjustProps) {
 
 	// Helper to reset image to original state
 	const resetImage = useCallback(
-		(imageId: string) => {
-			calculateImageFit(imageId, "cover");
+		(image: ImageElement) => {
+			calculateImageFit(
+				image.id,
+				"cover",
+				image?.naturalWidth || 200,
+				image?.naturalHeight || 200,
+			);
 		},
 		[calculateImageFit],
 	);

--- a/src/features/editor/hooks/use-template-editor.ts
+++ b/src/features/editor/hooks/use-template-editor.ts
@@ -106,6 +106,7 @@ export function useTemplateEditor(initial?: TemplateData) {
 			position: { x: template.width / 2 - 100, y: template.height / 2 - 100 },
 			width: 200,
 			height: 200,
+
 			draggable: true,
 		};
 		setTemplate((p) => ({

--- a/src/shared/types/template.ts
+++ b/src/shared/types/template.ts
@@ -23,6 +23,8 @@ export interface ImageElement {
 	scaleY?: number;
 	centerX?: boolean;
 	centerY?: boolean;
+	naturalWidth?: number;
+	naturalHeight?: number;
 }
 export interface CropArea {
 	x: number;

--- a/src/shared/types/template.ts
+++ b/src/shared/types/template.ts
@@ -19,9 +19,16 @@ export interface ImageElement {
 	borderRadius?: number;
 	grayscale?: boolean;
 	imageOffset?: { x: number; y: number };
-	imageScale?: number;
+	scaleX?: number;
+	scaleY?: number;
 	centerX?: boolean;
 	centerY?: boolean;
+}
+export interface CropArea {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
 }
 
 export interface TextElement {


### PR DESCRIPTION
This pull request introduces a new, fully-featured `CropModal` component for cropping images in the editor, and refactors image scaling logic throughout the `TemplateImage` component for improved accuracy and flexibility. The changes also update the logic for initializing and applying image crop and scaling, and improve the UI/UX for image selection and drag-and-drop.

**Key changes include:**

### New Crop Modal Functionality

- Added a new `CropModal` component (`crop-modal.tsx`) that provides a modal interface for cropping images, including drag-to-move, corner resizing, overlay grid lines, and live crop area display. The modal uses a portal for rendering and is highly responsive to viewport size.

### Image Scaling and Cropping Refactor

- Replaced the previous single `imageScale` property with separate `scaleX` and `scaleY` properties throughout the `TemplateImage` logic, allowing for more accurate non-uniform scaling and better handling of different aspect ratios. [[1]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L107-R106) [[2]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L134-L142) [[3]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7R148-R180) [[4]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L202-R190) [[5]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L213-R229) [[6]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L353-R343) [[7]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L378-R369)
- Improved the initialization of image scale and offset when loading images, ensuring the image fills the container appropriately based on its aspect ratio.
- Updated the logic for applying a crop so that the new scale and offset are calculated in terms of `scaleX`/`scaleY` rather than a single scale value.

### UI/UX Improvements

- Enhanced the drag-and-drop and selection UI for image elements, with improved ring and shadow styles for active and drag-over states.
- Updated the image placeholder to use a more visually appealing Unsplash image, and set images to be non-selectable for a smoother user experience.

### Type and Interface Updates

- Removed the local `CropArea` interface in favor of importing the shared type, ensuring consistency across the codebase. [[1]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L1-R4) [[2]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L35-L41)

**References:** [[1]](diffhunk://#diff-ef33854ac1fab74381cb4415c19ffc2c8acf934c9af55cb21d3b4af53d057df9R1-R228) [[2]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L1-R4) [[3]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L35-L41) [[4]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L86-L89) [[5]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L107-R106) [[6]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L134-L142) [[7]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L151-R139) [[8]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7R148-R180) [[9]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L202-R190) [[10]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L213-R229) [[11]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L353-R343) [[12]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L378-R369) [[13]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L634-R627) [[14]](diffhunk://#diff-40897e120e45922e6a9048fae32229b156e0151bdbcae0bc06d1a18fe21832f7L656-R652)