### PR TITLE
feat: add edit and delete actions for orders with no images

### DIFF
--- a/src/features/order-management/components/delete-order-dialog.tsx
+++ b/src/features/order-management/components/delete-order-dialog.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
+import { useDeleteOrderMutation } from "@/shared/repository/order/query";
+import type { Order } from "@/shared/types";
+import { toast } from "sonner";
+
+type Props = {
+	order: {
+		id: Order["id"];
+		orderNumber: Order["orderNumber"];
+		username: Order["username"];
+	};
+};
+
+export default function DeleteOrderDialog({ order }: Props) {
+	const { mutate: deleteOrder, isPending } = useDeleteOrderMutation({
+		id: order.id,
+	});
+	const { closeDialog } = useDialogStore();
+
+	const handleDelete = () => {
+		deleteOrder(undefined, {
+			onSuccess: (res) => {
+				if (!res.success) {
+					toast.error(res.message || "Failed to delete order");
+					return;
+				}
+
+				closeDialog();
+				toast.success(res.message || "Order deleted successfully");
+			},
+		});
+	};
+
+	return (
+		<DialogContent>
+			<DialogHeader>
+				<DialogTitle>Delete Order</DialogTitle>
+				<DialogDescription>
+					Are you sure you want to delete this order? This action cannot be
+					undone.
+				</DialogDescription>
+			</DialogHeader>
+			<div className="space-y-2">
+				<p className="text-sm text-gray-700">
+					<span className="font-medium">Order Number:</span> {order.orderNumber}
+				</p>
+				<p className="text-sm text-gray-700">
+					<span className="font-medium">Username:</span> {order.username}
+				</p>
+			</div>
+			<DialogFooter>
+				<Button variant="outline" onClick={closeDialog} disabled={isPending}>
+					Cancel
+				</Button>
+				<Button
+					variant="destructive"
+					onClick={handleDelete}
+					disabled={isPending}
+				>
+					{isPending ? "Deleting..." : "Delete Order"}
+				</Button>
+			</DialogFooter>
+		</DialogContent>
+	);
+}

--- a/src/features/order-management/components/edit-order-dialog.tsx
+++ b/src/features/order-management/components/edit-order-dialog.tsx
@@ -1,0 +1,216 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/shared/components/ui/form";
+import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
+import type { Order, Product, ProductVariant } from "@/shared/types";
+import { MinusIcon, PlusIcon } from "lucide-react";
+import { useFieldArray } from "react-hook-form";
+import { useEditOrderForm } from "../hooks/use-edit-order-form";
+
+type Props = {
+	order: {
+		id: Order["id"];
+		orderNumber: Order["orderNumber"];
+		username: Order["username"];
+		products: {
+			id: Product["id"];
+			name: Product["name"];
+			productVariant: {
+				id: ProductVariant["id"];
+				name: ProductVariant["name"];
+			};
+		}[];
+	};
+	products: (Product & {
+		variants: ProductVariant[];
+	})[];
+};
+
+export default function EditOrderDialog({ order, products }: Props) {
+	const form = useEditOrderForm(order);
+
+	const productVariantsArray = useFieldArray({
+		control: form.control,
+		name: "productVariants",
+	});
+
+	return (
+		<DialogContent>
+			<DialogHeader>
+				<DialogTitle>Edit Order</DialogTitle>
+				<DialogDescription>
+					Edit order details. Only available when no images have been uploaded.
+				</DialogDescription>
+			</DialogHeader>
+			<Form {...form}>
+				<form onSubmit={form.onSubmitHandler} className="space-y-4">
+					<FormField
+						control={form.control}
+						name="orderNumber"
+						render={({ field }) => {
+							return (
+								<FormItem>
+									<FormLabel>Order Number</FormLabel>
+									<FormControl>
+										<Input {...field} placeholder="Enter order number" />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							);
+						}}
+					/>
+					<FormField
+						control={form.control}
+						name="username"
+						render={({ field }) => {
+							return (
+								<FormItem>
+									<FormLabel>Username</FormLabel>
+									<FormControl>
+										<Input {...field} placeholder="Enter username" />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							);
+						}}
+					/>
+					<div className="space-y-2">
+						<div className="flex flex-row justify-between items-center">
+							<Label>Product Variants</Label>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => {
+									productVariantsArray.append({
+										productVariantId: products[0]?.variants[0]?.id || "",
+										quantity: 1,
+									});
+								}}
+							>
+								Add Variant
+							</Button>
+						</div>
+						{productVariantsArray.fields.length === 0 && (
+							<p className="text-sm text-gray-500 text-center">
+								No product variants added. Click "Add Variant" to include
+								products.
+							</p>
+						)}
+						{productVariantsArray.fields.map((field, index) => (
+							<div key={field.id} className="flex flex-row items-center gap-2">
+								<FormField
+									control={form.control}
+									name={`productVariants.${index}.productVariantId`}
+									render={({ field: productVariantField }) => {
+										return (
+											<FormItem className="flex-1">
+												<Select
+													onValueChange={(value) => {
+														productVariantField.onChange(value);
+													}}
+													value={productVariantField.value}
+												>
+													<FormControl>
+														<SelectTrigger className="w-full">
+															<SelectValue placeholder="Select a product variant" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														{products.map((product) =>
+															product.variants.map((variant) => (
+																<SelectItem key={variant.id} value={variant.id}>
+																	{`${product.name} - ${variant.name}`}
+																</SelectItem>
+															)),
+														)}
+													</SelectContent>
+												</Select>
+											</FormItem>
+										);
+									}}
+								/>
+								<FormField
+									control={form.control}
+									name={`productVariants.${index}.quantity`}
+									render={({ field: quantityField }) => (
+										<FormItem className="shrink">
+											<FormControl>
+												<div className="flex flex-row items-center gap-2">
+													<Button
+														type="button"
+														variant="outline"
+														size="icon"
+														onClick={() => {
+															const newValue = Math.max(
+																1,
+																(quantityField.value || 1) - 1,
+															);
+															quantityField.onChange(newValue);
+														}}
+													>
+														<MinusIcon className="size-4" />
+													</Button>
+													<Input
+														type="number"
+														min={1}
+														className="text-center w-16"
+														value={quantityField.value}
+														onChange={(e) => {
+															const value = Number.parseInt(e.target.value, 10);
+															quantityField.onChange(
+																Number.isNaN(value) ? 1 : value,
+															);
+														}}
+													/>
+													<Button
+														type="button"
+														variant="outline"
+														size="icon"
+														onClick={() => {
+															const newValue = (quantityField.value || 1) + 1;
+															quantityField.onChange(newValue);
+														}}
+													>
+														<PlusIcon className="size-4" />
+													</Button>
+												</div>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+						))}
+					</div>
+					<DialogFooter>
+						<Button type="submit">
+							{form.isLoading ? "Updating..." : "Update Order"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</Form>
+		</DialogContent>
+	);
+}

--- a/src/features/order-management/components/order-table.tsx
+++ b/src/features/order-management/components/order-table.tsx
@@ -9,6 +9,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/shared/components/ui/table";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
 import { tryCatch } from "@/shared/lib/try-catch";
 import { cn } from "@/shared/lib/utils";
 import type {
@@ -31,8 +32,10 @@ import {
 	ChevronRightIcon,
 	CopyIcon,
 	DownloadIcon,
+	EditIcon,
 	EyeIcon,
 	FilterIcon,
+	TrashIcon,
 } from "lucide-react";
 import Image from "next/image";
 import { Fragment, useState } from "react";
@@ -47,6 +50,8 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "../../../shared/components/ui/dialog";
+import EditOrderDialogContainer from "../container/edit-order-dialog-container";
+import DeleteOrderDialog from "./delete-order-dialog";
 
 type Props = {
 	data: {
@@ -76,6 +81,7 @@ export default function OrderTable({
 	onSortingChangeAction,
 }: Props) {
 	const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+	const { openDialog } = useDialogStore();
 
 	const toggleRowExpansion = (rowId: string) => {
 		const newExpanded = new Set(expandedRows);
@@ -184,6 +190,54 @@ export default function OrderTable({
 								<DownloadIcon className="h-4 w-4" />
 							</Button>
 						)}
+					</div>
+				);
+			},
+		},
+		{
+			header: "Actions",
+			enableSorting: false,
+			cell: (props) => {
+				const { products } = props.row.original;
+				const countHavingImages = products.filter((p) => p.imageUrl).length;
+				const hasNoImages = countHavingImages === 0;
+
+				if (!hasNoImages) return null;
+
+				const order = props.row.original;
+
+				return (
+					<div className="flex flex-row items-center gap-2">
+						<Button
+							variant="outline"
+							size="icon"
+							onClick={() => {
+								openDialog({
+									children: <EditOrderDialogContainer order={order} />,
+								});
+							}}
+						>
+							<EditIcon className="h-4 w-4" />
+						</Button>
+						<Button
+							variant="outline"
+							size="icon"
+							onClick={() => {
+								openDialog({
+									children: (
+										<DeleteOrderDialog
+											order={{
+												id: order.id,
+												orderNumber: order.orderNumber,
+												username: order.username,
+											}}
+										/>
+									),
+								});
+							}}
+						>
+							<TrashIcon className="h-4 w-4" />
+						</Button>
 					</div>
 				);
 			},

--- a/src/features/order-management/container/edit-order-dialog-container.tsx
+++ b/src/features/order-management/container/edit-order-dialog-container.tsx
@@ -1,0 +1,56 @@
+import {
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useGetProductsQuery } from "@/shared/repository/product/query";
+import type { Order, Product, ProductVariant } from "@/shared/types";
+import { Loader2Icon } from "lucide-react";
+import EditOrderDialog from "../components/edit-order-dialog";
+
+type Props = {
+	order: {
+		id: Order["id"];
+		orderNumber: Order["orderNumber"];
+		username: Order["username"];
+		products: {
+			id: Product["id"];
+			name: Product["name"];
+			productVariant: {
+				id: ProductVariant["id"];
+				name: ProductVariant["name"];
+			};
+		}[];
+	};
+};
+
+export default function EditOrderDialogContainer({ order }: Props) {
+	const { data: res, isLoading } = useGetProductsQuery({});
+
+	if (isLoading) {
+		return (
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						<Skeleton className="w-28 h-8" />
+					</DialogTitle>
+				</DialogHeader>
+				<Loader2Icon className="animate-spin h-6 w-6 text-gray-500" />
+			</DialogContent>
+		);
+	}
+
+	if (!res?.success || !res.data) {
+		return (
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Error</DialogTitle>
+				</DialogHeader>
+				<div className="text-red-500">Failed to fetch products</div>
+			</DialogContent>
+		);
+	}
+
+	return <EditOrderDialog order={order} products={res.data.products} />;
+}

--- a/src/features/order-management/hooks/use-edit-order-form.ts
+++ b/src/features/order-management/hooks/use-edit-order-form.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useDialogStore } from "@/shared/hooks/use-dialog";
+import {
+	type UpdateOrderRequest,
+	updateOrderSchema,
+} from "@/shared/repository/order/dto";
+import { useUpdateOrderMutation } from "@/shared/repository/order/query";
+import type { Order, Product, ProductVariant } from "@/shared/types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+type OrderData = {
+	id: Order["id"];
+	orderNumber: Order["orderNumber"];
+	username: Order["username"];
+	products: {
+		id: Product["id"];
+		name: Product["name"];
+		productVariant: {
+			id: ProductVariant["id"];
+			name: ProductVariant["name"];
+		};
+	}[];
+};
+
+export const useEditOrderForm = (order: OrderData) => {
+	const { mutate: updateOrder, isPending } = useUpdateOrderMutation({
+		id: order.id,
+	});
+	const { closeDialog } = useDialogStore();
+
+	// Count the occurrences of each product variant
+	const productVariantCounts = order.products.reduce(
+		(acc, product) => {
+			const variantId = product.productVariant.id;
+			acc[variantId] = (acc[variantId] || 0) + 1;
+			return acc;
+		},
+		{} as Record<string, number>,
+	);
+
+	// Convert to the format expected by the form
+	const initialProductVariants = Object.entries(productVariantCounts).map(
+		([productVariantId, quantity]) => ({
+			productVariantId,
+			quantity,
+		}),
+	);
+
+	const form = useForm<UpdateOrderRequest>({
+		resolver: zodResolver(updateOrderSchema),
+		defaultValues: {
+			orderNumber: order.orderNumber,
+			username: order.username,
+			productVariants: initialProductVariants,
+		},
+	});
+
+	const onSubmitHandler = form.handleSubmit((data) => {
+		updateOrder(data, {
+			onSuccess: (res) => {
+				if (!res.success) {
+					toast.error(res.message || "Failed to update order");
+					return;
+				}
+
+				form.reset();
+				closeDialog();
+				toast.success(res.message || "Order updated successfully");
+			},
+		});
+	});
+
+	return {
+		...form,
+		isLoading: isPending,
+		onSubmitHandler,
+	};
+};


### PR DESCRIPTION
## Summary
- Added edit and delete functionality for orders when they have no images uploaded (status: no-images)
- Edit and delete actions only visible when order has zero images
- Edit order allows changing order number, username, and product variants
- Delete order shows confirmation dialog before deletion

## Changes
- Add Actions column to order table with edit and delete buttons
- Create EditOrderDialog component for editing order details
- Create DeleteOrderDialog component for order deletion confirmation  
- Create EditOrderDialogContainer to handle product data fetching
- Create useEditOrderForm hook for managing edit form state
- Use existing updateOrder and deleteOrder mutations with proper query invalidation

## Test plan
- [ ] Verify edit and delete buttons only appear for orders with no images
- [ ] Test editing an order with no images
- [ ] Test deleting an order with no images
- [ ] Verify actions column is hidden for orders with partial or complete images
- [ ] Verify form validation in edit dialog
- [ ] Verify confirmation dialog in delete action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added order deletion capability with a confirmation dialog displaying order details before permanent removal.
  * Added order editing functionality allowing updates to order numbers, usernames, and product variants through a guided dialog interface.
  * Introduced action buttons in the order table for quick access to edit and delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->