### PR TITLE
Fix: Change default order status from 'progress' to 'no-images'

### DIFF
--- a/src/server/db/schema/orders.ts
+++ b/src/server/db/schema/orders.ts
@@ -5,7 +5,7 @@ export const ordersTable = pgTable("orders", {
 	id: uuid("id").primaryKey().defaultRandom(),
 	orderNumber: varchar("order_number", { length: 255 }).notNull(),
 	username: varchar({ length: 255 }).notNull(),
-	status: varchar("status", { length: 50 }).notNull().default("progress"),
+	status: varchar("status", { length: 50 }).notNull().default("no-images"),
 	createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 


### PR DESCRIPTION
## Summary
- Changed the default status for newly created orders from 'progress' to 'no-images'

## Description
Updated the database schema to set the correct initial status for orders. When an order is first created, it should have the status 'no-images' to accurately reflect that no images have been uploaded yet.

## Changes Made
- Updated `src/server/db/schema/orders.ts` to change the default value of the status field from "progress" to "no-images"

## Test Plan
- [ ] Create a new order and verify it has status 'no-images'
- [ ] Upload images and verify status changes to 'progress'
- [ ] Upload all images and verify status changes to 'completed'

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default status for newly created orders to ensure consistent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->