### PR TITLE
feat: add confirmation dialogs when submitting order templates

### DIFF
--- a/src/features/templates/components/order-completed-dialog.tsx
+++ b/src/features/templates/components/order-completed-dialog.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useTemplatesStore } from "../stores/use-templates-store";
+
+export default function OrderCompletedDialog() {
+	const { closeDialog } = useDialogStore();
+	const { deleteOrder } = useTemplatesStore();
+	const router = useRouter();
+
+	const handleOke = () => {
+		deleteOrder();
+		closeDialog();
+		window.location.href = "/templates/onboarding";
+	};
+
+	return (
+		<DialogContent showCloseButton={false} className="sm:max-w-sm">
+			<div className="relative size-48 w-full">
+				<Image
+					src="/svgs/success-1.svg"
+					alt="Success"
+					fill
+					objectFit="contain"
+				/>
+			</div>
+			<DialogHeader className="gap-4 sm:text-center">
+				<DialogTitle className="text-center text-[#1D2939] font-bold">
+					Pesanan berhasil dikirim!
+				</DialogTitle>
+				<DialogDescription className="text-center text-[#737373] text-sm">
+					Pesananmu akan segera diproses
+				</DialogDescription>
+			</DialogHeader>
+			<DialogFooter className="flex flex-row gap-2">
+				<Button
+					onClick={handleOke}
+					className="flex-1 px-8 py-4 h-fit bg-[#2854AD] hover:bg-[#2854AD]/80 rounded-md shadow-none text-base font-bold text-[#ffffff]"
+				>
+					Oke
+				</Button>
+			</DialogFooter>
+		</DialogContent>
+	);
+}

--- a/src/features/templates/components/order-completed-sheet.tsx
+++ b/src/features/templates/components/order-completed-sheet.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@/shared/components/ui/sheet";
+import { useSheetStore } from "@/shared/hooks/use-sheet";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useTemplatesStore } from "../stores/use-templates-store";
+
+export default function OrderCompletedSheet() {
+	const { closeSheet } = useSheetStore();
+	const { deleteOrder } = useTemplatesStore();
+	const router = useRouter();
+
+	const handleOke = () => {
+		deleteOrder();
+		closeSheet();
+		window.location.href = "/templates/onboarding";
+	};
+
+	return (
+		<SheetContent side="bottom">
+			<div className="relative size-48 w-full">
+				<Image
+					src="/svgs/success-1.svg"
+					alt="Success"
+					fill
+					objectFit="contain"
+				/>
+			</div>
+			<SheetHeader className="gap-4 sm:text-center">
+				<SheetTitle className="text-center text-[#1D2939] font-bold">
+					Pesanan berhasil dikirim!
+				</SheetTitle>
+				<SheetDescription className="text-center text-[#737373] text-sm">
+					Pesananmu akan segera diproses
+				</SheetDescription>
+			</SheetHeader>
+			<SheetFooter className="flex flex-row gap-2">
+				<Button
+					onClick={handleOke}
+					className="flex-1 px-8 py-4 h-fit bg-[#2854AD] hover:bg-[#2854AD]/80 rounded-md shadow-none text-base font-bold text-[#ffffff]"
+				>
+					Oke
+				</Button>
+			</SheetFooter>
+		</SheetContent>
+	);
+}

--- a/src/features/templates/components/order-incomplete-dialog.tsx
+++ b/src/features/templates/components/order-incomplete-dialog.tsx
@@ -1,0 +1,56 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
+import Image from "next/image";
+import { useTemplatesStore } from "../stores/use-templates-store";
+
+type Props = {
+	remainingCount: number;
+};
+
+export default function OrderIncompleteDialog({ remainingCount }: Props) {
+	const { closeDialog } = useDialogStore();
+	const { deleteOrder } = useTemplatesStore();
+
+	const handleOke = () => {
+		deleteOrder();
+		closeDialog();
+		window.location.href = "/templates/onboarding";
+	};
+
+	return (
+		<DialogContent showCloseButton={false} className="sm:max-w-sm">
+			<div className="relative size-48 w-full">
+				<Image
+					src="/svgs/success-1.svg"
+					alt="Success"
+					fill
+					objectFit="contain"
+				/>
+			</div>
+			<DialogHeader className="gap-4 sm:text-center">
+				<DialogTitle className="text-center text-[#1D2939] font-bold">
+					Template berhasil dikirim!
+				</DialogTitle>
+				<DialogDescription className="text-center text-[#737373] text-sm">
+					Kamu masih perlu mengisi {remainingCount} template lagi untuk
+					menyelesaikan pesanan
+				</DialogDescription>
+			</DialogHeader>
+			<DialogFooter className="flex flex-row gap-2">
+				<Button
+					onClick={handleOke}
+					className="flex-1 px-8 py-4 h-fit bg-[#2854AD] hover:bg-[#2854AD]/80 rounded-md shadow-none text-base font-bold text-[#ffffff]"
+				>
+					Oke
+				</Button>
+			</DialogFooter>
+		</DialogContent>
+	);
+}

--- a/src/features/templates/components/order-incomplete-sheet.tsx
+++ b/src/features/templates/components/order-incomplete-sheet.tsx
@@ -1,0 +1,56 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@/shared/components/ui/sheet";
+import { useSheetStore } from "@/shared/hooks/use-sheet";
+import Image from "next/image";
+import { useTemplatesStore } from "../stores/use-templates-store";
+
+type Props = {
+	remainingCount: number;
+};
+
+export default function OrderIncompleteSheet({ remainingCount }: Props) {
+	const { closeSheet } = useSheetStore();
+	const { deleteOrder } = useTemplatesStore();
+
+	const handleOke = () => {
+		deleteOrder();
+		closeSheet();
+		window.location.href = "/templates/onboarding";
+	};
+
+	return (
+		<SheetContent side="bottom">
+			<div className="relative size-48 w-full">
+				<Image
+					src="/svgs/success-1.svg"
+					alt="Success"
+					fill
+					objectFit="contain"
+				/>
+			</div>
+			<SheetHeader className="gap-4 sm:text-center">
+				<SheetTitle className="text-center text-[#1D2939] font-bold">
+					Template berhasil dikirim!
+				</SheetTitle>
+				<SheetDescription className="text-center text-[#737373] text-sm">
+					Kamu masih perlu mengisi {remainingCount} template lagi untuk
+					menyelesaikan pesanan
+				</SheetDescription>
+			</SheetHeader>
+			<SheetFooter className="flex flex-row gap-2">
+				<Button
+					onClick={handleOke}
+					className="flex-1 px-8 py-4 h-fit bg-[#2854AD] hover:bg-[#2854AD]/80 rounded-md shadow-none text-base font-bold text-[#ffffff]"
+				>
+					Oke
+				</Button>
+			</SheetFooter>
+		</SheetContent>
+	);
+}


### PR DESCRIPTION
## Summary
Implements confirmation dialogs that appear after submitting order templates, providing clear feedback about order status and next steps.

## Changes

### Order Completed Dialog/Sheet
- Shows when all templates are filled (status = "completed")
- Displays message: "Pesananmu akan segera diproses"
- User clicks "Oke" → Order deleted from store → Redirected to onboarding

### Order Incomplete Dialog/Sheet  
- Shows when templates remain to be filled
- Displays remaining count: "Kamu masih perlu mengisi X template lagi untuk menyelesaikan pesanan"
- User clicks "Oke" → Order deleted from store → Redirected to onboarding

### Backend Updates
- `submitOrder` action now returns:
  - `status`: Order completion status
  - `remainingCount`: Number of templates still needed (totalProducts - productsWithImages)

### UI/UX Improvements
- Removed "dan tunggu pesanan kamu sampe yaa" from confirmation text
- Replaced toast notifications with dialog confirmations for better visibility
- Fixed redirect issue (#66) by using `window.location.href`

## Related Issues
Closes #69
Fixes #66

## Test Plan
- [x] Submit templates when all are filled → Order completed dialog appears
- [x] Submit templates when some remain → Order incomplete dialog shows correct count
- [x] Click "Oke" button → Successfully redirected to onboarding
- [x] Verify order is deleted from store after redirect
- [ ] Test on both desktop (dialog) and mobile (sheet) views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced order submission flow with dedicated confirmation screens.
  * Users now receive immediate feedback on order completion status.
  * Displays count of remaining templates when orders are pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->