### PR TITLE
Change send button color from black to blue

### DIFF
--- a/src/features/templates/components/send-dialog-button.tsx
+++ b/src/features/templates/components/send-dialog-button.tsx
@@ -10,7 +10,7 @@ export default function SendDialogButton() {
 
 	return (
 		<Button
-			className="gap-2 font-medium text-xs text-white bg-black px-4 py-3 rounded-md h-fit hidden sm:flex"
+			className="gap-2 font-medium text-xs bg-[#2854AD] hover:bg-[#2854AD]/80 text-white shadow-none px-4 py-3 rounded-md h-fit hidden sm:flex"
 			onClick={() => {
 				openDialog({
 					children: <SendDialog />,

--- a/src/features/templates/components/send-sheet-button.tsx
+++ b/src/features/templates/components/send-sheet-button.tsx
@@ -11,7 +11,7 @@ export default function SendSheetButton() {
 	return (
 		<Button
 			size="lg"
-			className="gap-2 font-medium text-xs text-white bg-black px-4 py-3 rounded-md h-fit w-full"
+			className="gap-2 font-medium text-xs bg-[#2854AD] hover:bg-[#2854AD]/80 text-white shadow-none px-4 py-3 rounded-md h-fit w-full"
 			onClick={() => {
 				openSheet({
 					children: <SendSheet />,


### PR DESCRIPTION
## Summary
- Updated send button components (dialog and sheet variants) to use blue brand color (#2854AD) instead of black
- Added hover states with 80% opacity for better UX
- Removed default button shadow for cleaner appearance

## Changes
- Updated `SendDialogButton` component with new blue color scheme
- Updated `SendSheetButton` component with new blue color scheme

## Test plan
- [x] Verify send button appears in blue (#2854AD) on desktop view (dialog)
- [x] Verify send button appears in blue (#2854AD) on mobile view (sheet)
- [x] Test hover interaction shows proper color transition
- [x] Confirm button functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated action button styling with a new blue color scheme and interactive hover effects for enhanced visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->