### PR TITLE
Fix preview image modal/sheet responsiveness

### DIFF
--- a/src/features/editor/containers/template-editor.tsx
+++ b/src/features/editor/containers/template-editor.tsx
@@ -290,7 +290,7 @@ function ConfirmationDialog({
 				<SheetTrigger asChild>
 					<Button variant="outline">Simpan</Button>
 				</SheetTrigger>
-				<SheetContent side="bottom">
+				<SheetContent side="bottom" className="max-h-[90vh] overflow-y-auto">
 					<SheetHeader className="gap-4 sm:text-center">
 						<SheetTitle className="text-center text-[#1D2939] font-bold">
 							Ini Preview Template kamu
@@ -300,8 +300,12 @@ function ConfirmationDialog({
 							tombol di bawah. Kalau udah oke, bisa lanjut ke produk berikutnya
 						</SheetDescription>
 					</SheetHeader>
-					<div className="flex flex-col items-center justify-center">
-						<img id="preview" alt="Preview" className="border" />
+					<div className="flex flex-col items-center justify-center py-4">
+						<img
+							id="preview"
+							alt="Preview"
+							className="border max-w-full max-h-[50vh] object-contain"
+						/>
 					</div>
 					<SheetFooter className="flex flex-row gap-2">
 						<SheetClose asChild>
@@ -329,7 +333,10 @@ function ConfirmationDialog({
 			<DialogTrigger asChild>
 				<Button variant="outline">Simpan</Button>
 			</DialogTrigger>
-			<DialogContent showCloseButton={false}>
+			<DialogContent
+				showCloseButton={false}
+				className="max-w-[90vw] md:max-w-2xl max-h-[90vh] overflow-y-auto"
+			>
 				<DialogHeader className="gap-4 sm:text-center">
 					<DialogTitle className="text-center text-[#1D2939] font-bold">
 						Ini Preview Template kamu
@@ -339,8 +346,12 @@ function ConfirmationDialog({
 						di bawah. Kalau udah oke, bisa lanjut ke produk berikutnya
 					</DialogDescription>
 				</DialogHeader>
-				<div className="flex flex-col items-center justify-center">
-					<img id="preview" alt="Preview" className="border" />
+				<div className="flex flex-col items-center justify-center py-4">
+					<img
+						id="preview"
+						alt="Preview"
+						className="border max-w-full max-h-[60vh] object-contain"
+					/>
 				</div>
 				<DialogFooter className="flex flex-row gap-2">
 					<DialogClose asChild>


### PR DESCRIPTION
## Summary
- Fixed ConfirmationDialog preview image responsiveness for mobile and desktop
- Added proper viewport constraints and image sizing to prevent overflow
- Improved user experience on all screen sizes

## Changes Made

### Mobile Sheet (SheetContent)
- Added `max-h-[90vh]` and `overflow-y-auto` to handle tall content gracefully
- Added `py-4` padding to image container for better spacing
- Set preview image constraints: `max-w-full max-h-[50vh] object-contain`

### Desktop Dialog (DialogContent)
- Added responsive width: `max-w-[90vw] md:max-w-2xl`
- Added `max-h-[90vh] overflow-y-auto` for scrollable overflow
- Added `py-4` padding to image container
- Set preview image constraints: `max-w-full max-h-[60vh] object-contain`

## Benefits
- ✅ Images scale properly on all screen sizes (mobile, tablet, desktop)
- ✅ Content doesn't overflow viewport on small screens
- ✅ Images maintain aspect ratio with `object-contain`
- ✅ Modal/sheet becomes scrollable if content exceeds viewport height
- ✅ Optimized spacing for different devices (50vh on mobile, 60vh on desktop)

## Test Plan
- [x] Test on mobile devices (< 640px width)
- [x] Test on tablets (640px - 1024px width)
- [x] Test on desktop (> 1024px width)
- [x] Verify image scaling with different aspect ratios
- [ ] Verify scrolling works when content is too tall

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview modals now properly constrain and scale content with responsive sizing across mobile and desktop views.
  * Preview images display with correct aspect ratios and fit appropriately within containers.
  * Large preview content is now scrollable to prevent overflow and maintain usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->