### PR TITLE
feat: add welcome dialog for first-time visitors to /templates

### DIFF
--- a/src/features/templates/components/first-visit-dialog.tsx
+++ b/src/features/templates/components/first-visit-dialog.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
+import Image from "next/image";
+
+export default function FirstVisitDialog() {
+	const { closeDialog } = useDialogStore();
+
+	const handleContinue = () => {
+		closeDialog();
+	};
+
+	return (
+		<DialogContent showCloseButton={false} className="sm:max-w-md">
+			<DialogHeader className="gap-4 sm:text-center">
+				<DialogTitle className="text-center text-[#1D2939] font-bold text-2xl">
+					Selamat Datang!
+				</DialogTitle>
+				<DialogDescription className="text-center text-[#737373] text-sm leading-relaxed">
+					Ini adalah halaman untuk mengkustomisasi template gift kamu. Pilih
+					produk, desain template sesuai keinginan, dan kirim pesananmu!
+				</DialogDescription>
+			</DialogHeader>
+			<DialogFooter className="flex flex-row gap-2">
+				<Button
+					onClick={handleContinue}
+					className="flex-1 px-8 py-4 h-fit bg-[#2854AD] hover:bg-[#2854AD]/80 rounded-md shadow-none text-base font-bold text-[#ffffff]"
+				>
+					Mulai Sekarang
+				</Button>
+			</DialogFooter>
+		</DialogContent>
+	);
+}

--- a/src/features/templates/containers/main-container.tsx
+++ b/src/features/templates/containers/main-container.tsx
@@ -6,17 +6,22 @@ import ListFilledTemplates from "@/features/templates/components/list-filled-tem
 import ListTemplates from "@/features/templates/components/list-templates";
 import SendDialogButton from "@/features/templates/components/send-dialog-button";
 import SendSheetButton from "@/features/templates/components/send-sheet-button";
+import { useFirstVisitStore } from "@/features/templates/stores/use-first-visit-store";
 import { useTemplatesStore } from "@/features/templates/stores/use-templates-store";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
+import { useDialogStore } from "@/shared/hooks/use-dialog";
 import { cn } from "@/shared/lib/utils";
 import { useSearchParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import FirstVisitDialog from "../components/first-visit-dialog";
 import Header from "../components/header";
 
 export default function MainContainer() {
 	const {
 		order: { productVariants },
 	} = useTemplatesStore();
+	const { hasVisitedTemplates, setVisited } = useFirstVisitStore();
+	const { openDialog } = useDialogStore();
 
 	const searchParams = useSearchParams();
 	const productVariantId = searchParams.get("productVariantId");
@@ -25,6 +30,15 @@ export default function MainContainer() {
 		productVariants.find((pv) => pv.id === productVariantId) ||
 			productVariants[0],
 	);
+
+	useEffect(() => {
+		if (!hasVisitedTemplates) {
+			openDialog({
+				children: <FirstVisitDialog />,
+			});
+			setVisited();
+		}
+	}, [hasVisitedTemplates, openDialog, setVisited]);
 
 	const hasFillAllTemplates = useMemo(() => {
 		if (productVariantId) {

--- a/src/features/templates/stores/use-first-visit-store.ts
+++ b/src/features/templates/stores/use-first-visit-store.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type FirstVisitStore = {
+	hasVisitedTemplates: boolean;
+	setVisited: () => void;
+};
+
+export const useFirstVisitStore = create<FirstVisitStore>()(
+	persist(
+		(set) => ({
+			hasVisitedTemplates: false,
+			setVisited: () => set({ hasVisitedTemplates: true }),
+		}),
+		{
+			name: "first-visit-store",
+			storage: createJSONStorage(() => sessionStorage),
+		},
+	),
+);


### PR DESCRIPTION
## Summary
- Add a pop-up dialog that displays when users visit the `/templates` page for the first time in a session
- The dialog provides a welcome message explaining the template customization feature
- Dialog shows once per browser session using sessionStorage

## Changes
- **Created** `FirstVisitDialog` component with welcome message and "Mulai Sekarang" button
- **Created** `useFirstVisitStore` Zustand store with sessionStorage persistence to track visit state
- **Modified** `MainContainer` to integrate dialog trigger logic using useEffect hook
- Dialog automatically opens on first visit and marks the session as visited

## Technical Details
- Uses Zustand with persist middleware for state management
- Persists to sessionStorage (not localStorage) so dialog reappears in new sessions
- Follows existing codebase patterns (Radix UI Dialog, global dialog store)
- Integrates seamlessly with existing `useDialogStore` hook

## Test Plan
- [x] Visit `/templates` for the first time - dialog should appear
- [x] Close the dialog and refresh the page - dialog should not appear again
- [x] Clear sessionStorage or start new browser session - dialog should appear again
- [x] Verify dialog follows design system (colors, fonts, spacing)
- [x] Ensure dialog is responsive on mobile and desktop

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added an automatic first-visit welcome dialog to the templates section that greets new users on their initial access. The dialog includes an introductory message and a button to proceed, enhancing the user onboarding experience by providing context and guidance at the point of entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->